### PR TITLE
Add query resolver for an entry

### DIFF
--- a/backend/config/passport.js
+++ b/backend/config/passport.js
@@ -3,7 +3,7 @@ import saml from 'passport-saml'
 
 import config from './index'
 import User from '../models/user'
-import { STUDENT } from '../permissionLevels'
+import { STUDENT } from '../constants'
 
 const samlConfig = config.get('auth:saml')
 

--- a/backend/constants.js
+++ b/backend/constants.js
@@ -1,0 +1,6 @@
+export const STUDENT = 'STUDENT'
+export const ADMIN = 'ADMIN'
+export const JUDGE = 'JUDGE'
+export const IMAGE_ENTRY = 0x1
+export const VIDEO_ENTRY = 0x2
+export const OTHER_ENTRY = 0x3

--- a/backend/db/migrations/20171029230713-create-user.js
+++ b/backend/db/migrations/20171029230713-create-user.js
@@ -1,4 +1,4 @@
-import { STUDENT, ADMIN, JUDGE } from '../../permissionLevels'
+import { STUDENT, ADMIN, JUDGE } from '../../constants'
 
 export function up (queryInterface, Sequelize) {
   return queryInterface.createTable('users', {

--- a/backend/db/migrations/20171116192217-create-entry.js
+++ b/backend/db/migrations/20171116192217-create-entry.js
@@ -1,0 +1,56 @@
+export function up (queryInterface, Sequelize) {
+  return queryInterface.createTable('entries', {
+    id: {
+      allowNull: false,
+      autoIncrement: true,
+      primaryKey: true,
+      type: Sequelize.INTEGER
+    },
+    entrantType: {
+      allowNull: false,
+      type: Sequelize.INTEGER
+    },
+    entrantId: {
+      allowNull: false,
+      type: Sequelize.INTEGER
+    },
+    entryType: {
+      allowNull: false,
+      type: Sequelize.INTEGER
+    },
+    entryId: {
+      allowNull: false,
+      type: Sequelize.INTEGER
+    },
+    title: {
+      type: Sequelize.STRING,
+      allowNull: false
+    },
+    comment: {
+      type: Sequelize.TEXT
+    },
+    moreCopies: {
+      allowNull: false,
+      type: Sequelize.BOOLEAN
+    },
+    forSale: {
+      allowNull: false,
+      type: Sequelize.BOOLEAN
+    },
+    awardWon: {
+      type: Sequelize.TEXT
+    },
+    createdAt: {
+      allowNull: false,
+      type: Sequelize.DATE
+    },
+    updatedAt: {
+      allowNull: false,
+      type: Sequelize.DATE
+    }
+  })
+}
+
+export function down (queryInterface) {
+  return queryInterface.dropTable('entries')
+}

--- a/backend/db/migrations/20171116200117-create-group.js
+++ b/backend/db/migrations/20171116200117-create-group.js
@@ -1,10 +1,14 @@
 export function up (queryInterface, Sequelize) {
-  return queryInterface.createTable('group', {
+  return queryInterface.createTable('groups', {
     id: {
       allowNull: false,
       autoIncrement: true,
       primaryKey: true,
       type: Sequelize.INTEGER
+    },
+    name: {
+      allowNull: false,
+      type: Sequelize.STRING
     },
     createdAt: {
       allowNull: false,

--- a/backend/db/migrations/20171116201012-create-image.1.js
+++ b/backend/db/migrations/20171116201012-create-image.1.js
@@ -1,0 +1,37 @@
+export function up (queryInterface, Sequelize) {
+  return queryInterface.createTable('images', {
+    id: {
+      allowNull: false,
+      autoIncrement: true,
+      primaryKey: true,
+      type: Sequelize.INTEGER
+    },
+    path: {
+      type: Sequelize.STRING
+    },
+    horizDimInch: {
+      type: Sequelize.FLOAT
+    },
+    vertDimInch: {
+      type: Sequelize.FLOAT
+    },
+    mediaType: {
+      type: Sequelize.STRING
+    },
+    title: {
+      type: Sequelize.STRING
+    },
+    createdAt: {
+      allowNull: false,
+      type: Sequelize.DATE
+    },
+    updatedAt: {
+      allowNull: false,
+      type: Sequelize.DATE
+    }
+  })
+}
+
+export function down (queryInterface) {
+  return queryInterface.dropTable('images')
+}

--- a/backend/db/migrations/20171116201012-create-image.js
+++ b/backend/db/migrations/20171116201012-create-image.js
@@ -18,9 +18,6 @@ export function up (queryInterface, Sequelize) {
     mediaType: {
       type: Sequelize.STRING
     },
-    title: {
-      type: Sequelize.STRING
-    },
     createdAt: {
       allowNull: false,
       type: Sequelize.DATE

--- a/backend/db/migrations/20171116210017-create-image.js
+++ b/backend/db/migrations/20171116210017-create-image.js
@@ -1,0 +1,22 @@
+export function up (queryInterface, Sequelize) {
+  return queryInterface.createTable('group', {
+    id: {
+      allowNull: false,
+      autoIncrement: true,
+      primaryKey: true,
+      type: Sequelize.INTEGER
+    },
+    createdAt: {
+      allowNull: false,
+      type: Sequelize.DATE
+    },
+    updatedAt: {
+      allowNull: false,
+      type: Sequelize.DATE
+    }
+  })
+}
+
+export function down (queryInterface) {
+  return queryInterface.dropTable('group')
+}

--- a/backend/db/migrations/20171116292217-create-entry.js
+++ b/backend/db/migrations/20171116292217-create-entry.js
@@ -71,6 +71,10 @@ export function up (queryInterface, Sequelize) {
       allowNull: true,
       type: Sequelize.TEXT
     },
+    excludeFromJudging: {
+      allowNull: false,
+      type: Sequelize.BOOLEAN
+    },
     createdAt: {
       allowNull: false,
       type: Sequelize.DATE

--- a/backend/db/migrations/20171116292217-create-entry.js
+++ b/backend/db/migrations/20171116292217-create-entry.js
@@ -63,6 +63,14 @@ export function up (queryInterface, Sequelize) {
       allowNull: true,
       type: Sequelize.BOOLEAN
     },
+    yearLevel: {
+      allowNull: true,
+      type: Sequelize.TEXT
+    },
+    academicProgram: {
+      allowNull: true,
+      type: Sequelize.TEXT
+    },
     createdAt: {
       allowNull: false,
       type: Sequelize.DATE

--- a/backend/db/migrations/20171116292217-create-entry.js
+++ b/backend/db/migrations/20171116292217-create-entry.js
@@ -6,13 +6,32 @@ export function up (queryInterface, Sequelize) {
       primaryKey: true,
       type: Sequelize.INTEGER
     },
-    entrantType: {
-      allowNull: false,
-      type: Sequelize.INTEGER
+    showId: {
+      type: Sequelize.INTEGER,
+      references: {
+        model: 'shows',
+        key: 'id'
+      },
+      onUpdate: 'cascade',
+      onDelete: 'cascade'
     },
-    entrantId: {
-      allowNull: false,
-      type: Sequelize.INTEGER
+    studentUsername: {
+      type: Sequelize.STRING,
+      references: {
+        model: 'users',
+        key: 'username'
+      },
+      onUpdate: 'cascade',
+      onDelete: 'cascade'
+    },
+    groupId: {
+      type: Sequelize.INTEGER,
+      references: {
+        model: 'groups',
+        key: 'id'
+      },
+      onUpdate: 'cascade',
+      onDelete: 'cascade'
     },
     entryType: {
       allowNull: false,
@@ -39,6 +58,10 @@ export function up (queryInterface, Sequelize) {
     },
     awardWon: {
       type: Sequelize.TEXT
+    },
+    invited: {
+      allowNull: true,
+      type: Sequelize.BOOLEAN
     },
     createdAt: {
       allowNull: false,

--- a/backend/googleProvider.js
+++ b/backend/googleProvider.js
@@ -1,7 +1,7 @@
 import google from 'googleapis'
 import nconf from './config'
 import User from './models/user'
-import { STUDENT } from './permissionLevels'
+import { STUDENT } from './constants'
 
 const OAuth2 = google.auth.OAuth2
 

--- a/backend/middleware/parseJwtUser.js
+++ b/backend/middleware/parseJwtUser.js
@@ -1,6 +1,6 @@
 import jwt from 'jsonwebtoken'
 import nconf from '../config'
-import { ADMIN, JUDGE, STUDENT } from '../permissionLevels'
+import { ADMIN, JUDGE, STUDENT } from '../constants'
 
 export default function (req, res, next) {
   if (req.headers.authorization &&

--- a/backend/models/entry.js
+++ b/backend/models/entry.js
@@ -1,15 +1,7 @@
 import Image from './image'
 import DataTypes from 'sequelize'
 import sequelize from '../config/sequelize'
-
-const IMAGE = 3
-export const IMAGE_ENTRY = IMAGE
-
-const VIDEO = 4
-export const VIDEO_ENTRY = VIDEO
-
-const OTHER = 5
-export const OTHER_ENTRY = OTHER
+import { IMAGE_ENTRY } from '../constants'
 
 const Entry = sequelize.define('entry', {
   showId: {
@@ -54,6 +46,14 @@ const Entry = sequelize.define('entry', {
     allowNull: true,
     type: DataTypes.BOOLEAN
   },
+  yearLevel: {
+    allowNull: true,
+    type: DataTypes.TEXT
+  },
+  academicProgram: {
+    allowNull: true,
+    type: DataTypes.TEXT
+  },
   createdAt: {
     allowNull: false,
     type: DataTypes.DATE
@@ -68,7 +68,7 @@ const Entry = sequelize.define('entry', {
  * Gets the associated photo as a Promise
  */
 Entry.prototype.getImage = function getImage () {
-  if (this.entryType !== IMAGE) {
+  if (this.entryType !== IMAGE_ENTRY) {
     return Promise.resolve(null)
   }
   return Image.findOne({

--- a/backend/models/entry.js
+++ b/backend/models/entry.js
@@ -1,13 +1,27 @@
+import Image from './image'
 import DataTypes from 'sequelize'
 import sequelize from '../config/sequelize'
 
-export default sequelize.define('entry', {
-  entrantType: {
+const IMAGE = 3
+export const IMAGE_ENTRY = IMAGE
+
+const VIDEO = 4
+export const VIDEO_ENTRY = VIDEO
+
+const OTHER = 5
+export const OTHER_ENTRY = OTHER
+
+const Entry = sequelize.define('entry', {
+  showId: {
     allowNull: false,
     type: DataTypes.INTEGER
   },
-  entrantId: {
-    allowNull: false,
+  studentUsername: {
+    allowNull: true,
+    type: DataTypes.STRING
+  },
+  groupId: {
+    allowNull: true,
     type: DataTypes.INTEGER
   },
   entryType: {
@@ -36,6 +50,10 @@ export default sequelize.define('entry', {
   awardWon: {
     type: DataTypes.TEXT
   },
+  invited: {
+    allowNull: true,
+    type: DataTypes.BOOLEAN
+  },
   createdAt: {
     allowNull: false,
     type: DataTypes.DATE
@@ -45,3 +63,17 @@ export default sequelize.define('entry', {
     type: DataTypes.DATE
   }
 })
+
+/*
+ * Gets the associated photo as a Promise
+ */
+Entry.prototype.getImage = function getImage () {
+  if (this.entryType !== IMAGE) {
+    return Promise.resolve(null)
+  }
+  return Image.findOne({
+    where: {id: this.entryId}
+  })
+}
+
+export default Entry

--- a/backend/models/entry.js
+++ b/backend/models/entry.js
@@ -44,7 +44,8 @@ const Entry = sequelize.define('entry', {
   },
   invited: {
     allowNull: true,
-    type: DataTypes.BOOLEAN
+    type: DataTypes.BOOLEAN,
+    defaultValue: false
   },
   yearLevel: {
     allowNull: true,

--- a/backend/models/entry.js
+++ b/backend/models/entry.js
@@ -55,6 +55,11 @@ const Entry = sequelize.define('entry', {
     allowNull: true,
     type: DataTypes.TEXT
   },
+  excludeFromJudging: {
+    allowNull: false,
+    type: DataTypes.BOOLEAN,
+    defaultValue: false
+  },
   createdAt: {
     allowNull: false,
     type: DataTypes.DATE
@@ -62,6 +67,15 @@ const Entry = sequelize.define('entry', {
   updatedAt: {
     allowNull: false,
     type: DataTypes.DATE
+  }
+},
+{
+  validate: {
+    entrantPresentValidation () {
+      if (!this.studentUsername && !this.groupId) {
+        throw new Error('Entry must have an entrant')
+      }
+    }
   }
 })
 

--- a/backend/models/entry.js
+++ b/backend/models/entry.js
@@ -1,0 +1,47 @@
+import DataTypes from 'sequelize'
+import sequelize from '../config/sequelize'
+
+export default sequelize.define('entry', {
+  entrantType: {
+    allowNull: false,
+    type: DataTypes.INTEGER
+  },
+  entrantId: {
+    allowNull: false,
+    type: DataTypes.INTEGER
+  },
+  entryType: {
+    allowNull: false,
+    type: DataTypes.INTEGER
+  },
+  entryId: {
+    allowNull: false,
+    type: DataTypes.INTEGER
+  },
+  title: {
+    type: DataTypes.STRING,
+    allowNull: false
+  },
+  comment: {
+    type: DataTypes.TEXT
+  },
+  moreCopies: {
+    allowNull: false,
+    type: DataTypes.BOOLEAN
+  },
+  forSale: {
+    allowNull: false,
+    type: DataTypes.BOOLEAN
+  },
+  awardWon: {
+    type: DataTypes.TEXT
+  },
+  createdAt: {
+    allowNull: false,
+    type: DataTypes.DATE
+  },
+  updatedAt: {
+    allowNull: false,
+    type: DataTypes.DATE
+  }
+})

--- a/backend/models/group.js
+++ b/backend/models/group.js
@@ -1,13 +1,27 @@
 import DataTypes from 'sequelize'
 import sequelize from '../config/sequelize'
+import Entry, { GROUP_ENTRANT } from './entry'
 
 export default sequelize.define('group', {
   createdAt: {
     allowNull: false,
     type: DataTypes.DATE
   },
+  name: {
+    allowNull: false,
+    type: DataTypes.STRING
+  },
   updatedAt: {
     allowNull: false,
     type: DataTypes.DATE
+  }
+},
+{
+  getterMethods: {
+    getEntries () {
+      return Entry.findAll({
+        where: {entrantType: GROUP_ENTRANT, entrantId: this.id}
+      })
+    }
   }
 })

--- a/backend/models/group.js
+++ b/backend/models/group.js
@@ -1,6 +1,5 @@
 import DataTypes from 'sequelize'
 import sequelize from '../config/sequelize'
-import Entry, { GROUP_ENTRANT } from './entry'
 
 export default sequelize.define('group', {
   createdAt: {
@@ -14,14 +13,5 @@ export default sequelize.define('group', {
   updatedAt: {
     allowNull: false,
     type: DataTypes.DATE
-  }
-},
-{
-  getterMethods: {
-    getEntries () {
-      return Entry.findAll({
-        where: {entrantType: GROUP_ENTRANT, entrantId: this.id}
-      })
-    }
   }
 })

--- a/backend/models/group.js
+++ b/backend/models/group.js
@@ -1,0 +1,13 @@
+import DataTypes from 'sequelize'
+import sequelize from '../config/sequelize'
+
+export default sequelize.define('group', {
+  createdAt: {
+    allowNull: false,
+    type: DataTypes.DATE
+  },
+  updatedAt: {
+    allowNull: false,
+    type: DataTypes.DATE
+  }
+})

--- a/backend/models/image.js
+++ b/backend/models/image.js
@@ -10,10 +10,12 @@ export default sequelize.define('image', {
     notEmpty: true
   },
   horizDimInch: {
-    type: DataTypes.FLOAT
+    type: DataTypes.FLOAT,
+    allowNull: false
   },
   vertDimInch: {
-    type: DataTypes.FLOAT
+    type: DataTypes.FLOAT,
+    allowNull: false
   },
   mediaType: {
     type: DataTypes.STRING,

--- a/backend/models/image.js
+++ b/backend/models/image.js
@@ -1,17 +1,30 @@
-'use strict';
-module.exports = (sequelize, DataTypes) => {
-  var image = sequelize.define('image', {
-    photo: DataTypes.STRING,
-    horizDimInch: DataTypes.FLOAT,
-    vertDimInch: DataTypes.FLOAT,
-    mediaType: DataTypes.STRING,
-    title: DataTypes.STRING
-  }, {
-    classMethods: {
-      associate: function(models) {
-        // associations can be defined here
-      }
+import Entry, { IMAGE_ENTRY } from './entry'
+import DataTypes from 'sequelize'
+import sequelize from '../config/sequelize'
+
+export default sequelize.define('image', {
+  path: {
+    type: DataTypes.STRING,
+    allowNull: false,
+    notEmpty: true
+  },
+  horizDimInch: {
+    type: DataTypes.FLOAT
+  },
+  vertDimInch: {
+    type: DataTypes.FLOAT
+  },
+  mediaType: {
+    type: DataTypes.STRING,
+    allowNull: false
+  }
+},
+{
+  instanceMethods: {
+    getEntry () {
+      return Entry.findOne({
+        where: {entryType: IMAGE_ENTRY, entryId: this.id}
+      })
     }
-  });
-  return image;
-};
+  }
+})

--- a/backend/models/image.js
+++ b/backend/models/image.js
@@ -19,7 +19,8 @@ export default sequelize.define('image', {
   },
   mediaType: {
     type: DataTypes.STRING,
-    allowNull: false
+    allowNull: false,
+    notEmpty: true
   }
 },
 {
@@ -28,6 +29,16 @@ export default sequelize.define('image', {
       return Entry.findOne({
         where: {entryType: IMAGE_ENTRY, entryId: this.id}
       })
+    }
+  },
+  validate: {
+    dimensionsPositiveValidation () {
+      if (this.vertDimInch <= 0) {
+        throw new Error('vertDimInch must be positive')
+      }
+      if (this.horizDimInch <= 0) {
+        throw new Error('horizDimInch must be positive')
+      }
     }
   }
 })

--- a/backend/models/image.js
+++ b/backend/models/image.js
@@ -1,0 +1,17 @@
+'use strict';
+module.exports = (sequelize, DataTypes) => {
+  var image = sequelize.define('image', {
+    photo: DataTypes.STRING,
+    horizDimInch: DataTypes.FLOAT,
+    vertDimInch: DataTypes.FLOAT,
+    mediaType: DataTypes.STRING,
+    title: DataTypes.STRING
+  }, {
+    classMethods: {
+      associate: function(models) {
+        // associations can be defined here
+      }
+    }
+  });
+  return image;
+};

--- a/backend/models/image.js
+++ b/backend/models/image.js
@@ -1,4 +1,5 @@
-import Entry, { IMAGE_ENTRY } from './entry'
+import Entry from './entry'
+import { IMAGE_ENTRY } from '../constants'
 import DataTypes from 'sequelize'
 import sequelize from '../config/sequelize'
 

--- a/backend/models/index.js
+++ b/backend/models/index.js
@@ -1,7 +1,23 @@
 import User from './user'
+import Group from './group'
 import Show from './show'
+import Entry from './entry'
+import Image from './image'
 
 export default function () {
+  // Many users can be on many shows
   User.belongsToMany(Show, {through: 'user_shows', foreignKey: 'username'})
   Show.belongsToMany(User, {through: 'user_shows'})
+
+  // Users and groups can make many entires
+  Entry.belongsTo(User)
+  Entry.belongsTo(Group)
+  User.hasMany(Entry)
+  Group.hasMany(Entry)
+
+  // Many shows have many entires
+  Entry.belongsToMany(Show, {through: 'user_entries', foreignKey: 'username'})
+  Show.belongsToMany(Entry, {through: 'user_entries'})
+
+  // Images, Videos, and Other Media are Entries
 }

--- a/backend/models/index.js
+++ b/backend/models/index.js
@@ -1,23 +1,14 @@
-import User from './user'
-import Group from './group'
-import Show from './show'
 import Entry from './entry'
-import Image from './image'
+import Group from './group'
+import User from './user'
+import Show from './show'
 
 export default function () {
   // Many users can be on many shows
   User.belongsToMany(Show, {through: 'user_shows', foreignKey: 'username'})
   Show.belongsToMany(User, {through: 'user_shows'})
 
-  // Users and groups can make many entires
-  Entry.belongsTo(User)
-  Entry.belongsTo(Group)
-  User.hasMany(Entry)
-  Group.hasMany(Entry)
-
-  // Many shows have many entires
-  Entry.belongsToMany(Show, {through: 'user_entries', foreignKey: 'username'})
-  Show.belongsToMany(Entry, {through: 'user_entries'})
-
-  // Images, Videos, and Other Media are Entries
+  Entry.belongsTo(User, {foreignKey: 'studentUsername'})
+  Entry.belongsTo(Group, {foreignKey: 'groupId'})
+  Entry.belongsTo(Show, {foreignKey: 'showId'})
 }

--- a/backend/models/show.js
+++ b/backend/models/show.js
@@ -51,6 +51,4 @@ export default sequelize.define('show', {
       }
     }
   }
-}
-
-)
+})

--- a/backend/models/user.js
+++ b/backend/models/user.js
@@ -1,6 +1,7 @@
 import DataTypes from 'sequelize'
 import sequelize from '../config/sequelize'
 import { STUDENT, ADMIN, JUDGE } from '../permissionLevels'
+import Entry, { USER_ENTRANT } from './entry'
 
 export default sequelize.define('user', {
   username: {
@@ -26,5 +27,14 @@ export default sequelize.define('user', {
     type: DataTypes.ENUM(STUDENT, ADMIN, JUDGE),
     allowNull: false,
     notEmpty: true
+  }
+},
+{
+  getterMethods: {
+    getEntries () {
+      return Entry.findAll({
+        where: {entrantType: USER_ENTRANT, entrantId: this.id}
+      })
+    }
   }
 })

--- a/backend/models/user.js
+++ b/backend/models/user.js
@@ -1,6 +1,6 @@
 import DataTypes from 'sequelize'
 import sequelize from '../config/sequelize'
-import { STUDENT, ADMIN, JUDGE } from '../permissionLevels'
+import { STUDENT, ADMIN, JUDGE } from '../constants'
 
 export default sequelize.define('user', {
   username: {

--- a/backend/models/user.js
+++ b/backend/models/user.js
@@ -1,14 +1,13 @@
 import DataTypes from 'sequelize'
 import sequelize from '../config/sequelize'
 import { STUDENT, ADMIN, JUDGE } from '../permissionLevels'
-import Entry, { USER_ENTRANT } from './entry'
 
 export default sequelize.define('user', {
   username: {
     type: DataTypes.STRING,
     allowNull: false,
     notEmpty: true,
-    primaryKey: true  //RIT usernames are unique between individuals and cannot be changed
+    primaryKey: true // RIT usernames are unique between individuals and cannot be changed
   },
   firstName: {
     type: DataTypes.STRING,
@@ -27,14 +26,5 @@ export default sequelize.define('user', {
     type: DataTypes.ENUM(STUDENT, ADMIN, JUDGE),
     allowNull: false,
     notEmpty: true
-  }
-},
-{
-  getterMethods: {
-    getEntries () {
-      return Entry.findAll({
-        where: {entrantType: USER_ENTRANT, entrantId: this.id}
-      })
-    }
   }
 })

--- a/backend/permissionLevels.js
+++ b/backend/permissionLevels.js
@@ -1,3 +1,0 @@
-export const STUDENT = 'STUDENT'
-export const ADMIN = 'ADMIN'
-export const JUDGE = 'JUDGE'

--- a/backend/resolvers/index.js
+++ b/backend/resolvers/index.js
@@ -1,16 +1,20 @@
+import Entry from './types/entryType'
 import User from './types/userType'
 import DateScalar from './types/dateScalar'
 import Show from './types/showType'
+import * as EntryQuery from './queries/entryQuery'
 import * as ShowMutations from './mutations/show'
 import * as ShowQuery from './queries/showQuery'
 import * as UserQuery from './queries/userQuery'
 import * as JudgeMutations from './mutations/judge'
 
 export default {
+  ...Entry,
   ...User,
   ...DateScalar,
   ...Show,
   Query: {
+    ...EntryQuery,
     ...UserQuery,
     ...ShowQuery
   },

--- a/backend/resolvers/index.js
+++ b/backend/resolvers/index.js
@@ -2,6 +2,7 @@ import Entry from './types/entryType'
 import User from './types/userType'
 import DateScalar from './types/dateScalar'
 import Show from './types/showType'
+import * as EntryMutations from './mutations/entry'
 import * as EntryQuery from './queries/entryQuery'
 import * as ShowMutations from './mutations/show'
 import * as ShowQuery from './queries/showQuery'
@@ -19,6 +20,7 @@ export default {
     ...ShowQuery
   },
   Mutation: {
+    ...EntryMutations,
     ...ShowMutations,
     ...JudgeMutations
   }

--- a/backend/resolvers/mutations/entry.js
+++ b/backend/resolvers/mutations/entry.js
@@ -5,7 +5,7 @@ import { ADMIN, IMAGE_ENTRY } from '../../constants'
 
 export function createPhoto (_, args, req) {
   // TODO update the below to account for group submission rights
-  const submittingOwnWork = req.auth.username !== undefined && req.auth.username === args.input.studentUsername
+  const submittingOwnWork = req.auth.username !== undefined && req.auth.username === args.input.entry.studentUsername
   if (req.auth.type !== ADMIN && !submittingOwnWork) {
     // don't allow non-admins to submit work claiming to be from someone else
     throw new UserError('Permission Denied')

--- a/backend/resolvers/mutations/entry.js
+++ b/backend/resolvers/mutations/entry.js
@@ -1,0 +1,25 @@
+import { UserError } from 'graphql-errors'
+import Entry from '../../models/entry'
+import Image from '../../models/image'
+import { ADMIN, IMAGE_ENTRY } from '../../constants'
+
+export function createPhoto (_, args, req) {
+  // TODO update the below to account for group submission rights
+  const submittingOwnWork = req.auth.username !== undefined && req.auth.username === args.input.studentUsername
+  if (req.auth.type !== ADMIN && !submittingOwnWork) {
+    // don't allow non-admins to submit work claiming to be from someone else
+    throw new UserError('Permission Denied')
+  }
+  return Image.create({
+    path: args.input.path,
+    horizDimInch: args.input.horizDimInch,
+    vertDimInch: args.input.vertDimInch,
+    mediaType: args.input.mediaType
+  }).then((image) => {
+    return Entry.create({
+      ...args.input.entry,
+      entryType: IMAGE_ENTRY,
+      entryId: image.id
+    }).then((entry) => Object.assign(entry, image.dataValues))
+  })
+}

--- a/backend/resolvers/mutations/judge.js
+++ b/backend/resolvers/mutations/judge.js
@@ -1,7 +1,7 @@
 import { UserError } from 'graphql-errors'
 
 import User from '../../models/user'
-import { ADMIN, JUDGE, STUDENT } from '../../permissionLevels'
+import { ADMIN, JUDGE, STUDENT } from '../../constants'
 
 export function createJudge (_, args, req) {
   if (req.auth.type !== ADMIN) {

--- a/backend/resolvers/mutations/show.js
+++ b/backend/resolvers/mutations/show.js
@@ -1,6 +1,6 @@
 import Show from '../../models/show'
 import { UserError } from 'graphql-errors'
-import { ADMIN } from '../../permissionLevels'
+import { ADMIN } from '../../constants'
 
 export function createShow (_, args, req) {
   if (req.auth.type !== ADMIN) {

--- a/backend/resolvers/queries/entryQuery.js
+++ b/backend/resolvers/queries/entryQuery.js
@@ -1,0 +1,21 @@
+import Entry, { IMAGE_ENTRY } from '../../models/entry'
+import { UserError } from 'graphql-errors'
+import { ADMIN } from '../../permissionLevels'
+
+export function entries (_, args, req) {
+  if (req.auth.type !== ADMIN) {
+    throw new UserError('Permission Denied')
+  }
+  return Entry.findAll({where: args}).each((entry) => {
+    entry.student = entry.getUser()
+    entry.group = entry.getGroup()
+
+    if (entry.entryType === IMAGE_ENTRY) {
+      return entry.getImage().then((image) => {
+        return Object.assign(entry, image.dataValues)
+      })
+    } else {
+      throw new Error('unknown entry type')
+    }
+  })
+}

--- a/backend/resolvers/queries/entryQuery.js
+++ b/backend/resolvers/queries/entryQuery.js
@@ -1,6 +1,6 @@
-import Entry, { IMAGE_ENTRY } from '../../models/entry'
+import Entry from '../../models/entry'
 import { UserError } from 'graphql-errors'
-import { ADMIN } from '../../permissionLevels'
+import { ADMIN, IMAGE_ENTRY } from '../../constants'
 
 export function entries (_, args, req) {
   if (req.auth.type !== ADMIN) {

--- a/backend/resolvers/queries/userQuery.js
+++ b/backend/resolvers/queries/userQuery.js
@@ -1,6 +1,6 @@
 import User from '../../models/user'
 import { UserError } from 'graphql-errors'
-import { STUDENT, ADMIN, JUDGE } from '../../permissionLevels'
+import { STUDENT, ADMIN, JUDGE } from '../../constants'
 
 export function user (_, args, req) {
   const isRequestingOwnUser = req.auth.id !== undefined && req.auth.id === args.id

--- a/backend/resolvers/types/entryType.js
+++ b/backend/resolvers/types/entryType.js
@@ -1,0 +1,16 @@
+import { IMAGE_ENTRY, VIDEO_ENTRY, OTHER_ENTRY } from '../../models/entry'
+
+export default {
+  Entry: {
+    __resolveType (data, context, info) {
+      if (data.entryType === IMAGE_ENTRY) {
+        return info.schema.getType('Photo')
+      } else if (data.entryType === VIDEO_ENTRY) {
+        return info.schema.getType('Video')
+      } else if (data.entryType === OTHER_ENTRY) {
+        return info.schema.getType('OtherMedia')
+      }
+      throw new Error('Unknown entry type')
+    }
+  }
+}

--- a/backend/resolvers/types/entryType.js
+++ b/backend/resolvers/types/entryType.js
@@ -1,4 +1,4 @@
-import { IMAGE_ENTRY, VIDEO_ENTRY, OTHER_ENTRY } from '../../models/entry'
+import { IMAGE_ENTRY, VIDEO_ENTRY, OTHER_ENTRY } from '../../constants'
 
 export default {
   Entry: {

--- a/backend/schema.js
+++ b/backend/schema.js
@@ -78,7 +78,8 @@ interface Entry {
     invited: Boolean
     yearLevel: String
     academicProgram: String
-    moreCopies: Boolean    
+    moreCopies: Boolean
+    excludeFromJudging: Boolean
 }
 
 input EntryInput {
@@ -105,6 +106,7 @@ type Photo implements Entry {
     yearLevel: String
     academicProgram: String
     moreCopies: Boolean
+    excludeFromJudging: Boolean
     
     path: String
     horizDimInch: Float
@@ -132,6 +134,7 @@ type Video implements Entry {
     yearLevel: String
     academicProgram: String
     moreCopies: Boolean
+    excludeFromJudging: Boolean
     
     videoURL: String
 }
@@ -148,6 +151,7 @@ type OtherMedia implements Entry {
     yearLevel: String
     academicProgram: String
     moreCopies: Boolean
+    excludeFromJudging: Boolean
     
     photoPath: String
     moreCopies: Boolean

--- a/backend/schema.js
+++ b/backend/schema.js
@@ -75,17 +75,19 @@ interface Entry {
     show: Show
     comment: String
     forSale: Boolean
+    invited: Boolean
 }
 
 type Photo implements Entry {
     id: ID!
-    photoPath: String
+    path: String
     horizDimInch: Float
     vertDimInch: Float
     comment: String
     media: String
     moreCopies: Boolean
     forSale: Boolean
+    invited: Boolean
     group: Group
     student: User
     show: Show
@@ -99,6 +101,7 @@ type Video implements Entry {
     videoURL: String
     comment: String
     forSale: Boolean
+    invited: Boolean
 }
 
 type OtherMedia implements Entry {
@@ -110,6 +113,7 @@ type OtherMedia implements Entry {
     comment: String
     moreCopies: Boolean
     forSale: Boolean
+    invited: Boolean
 }
 
 enum UserType {
@@ -133,7 +137,7 @@ type Query {
     photos: [Photo]
     videos: [Video]
     otherMedia: [OtherMedia]
-    entries: [Entry]
+    entries(showId: ID): [Entry]
 }
 
 type Mutation {

--- a/backend/schema.js
+++ b/backend/schema.js
@@ -79,9 +79,6 @@ interface Entry {
 
 type Photo implements Entry {
     id: ID!
-    group: Group
-    student: User
-    show: Show
     photoPath: String
     horizDimInch: Float
     vertDimInch: Float
@@ -89,6 +86,9 @@ type Photo implements Entry {
     media: String
     moreCopies: Boolean
     forSale: Boolean
+    group: Group
+    student: User
+    show: Show
 }
 
 type Video implements Entry {

--- a/backend/schema.js
+++ b/backend/schema.js
@@ -76,6 +76,8 @@ interface Entry {
     comment: String
     forSale: Boolean
     invited: Boolean
+    yearLevel: String
+    academicProgram: String
 }
 
 type Photo implements Entry {
@@ -88,6 +90,8 @@ type Photo implements Entry {
     moreCopies: Boolean
     forSale: Boolean
     invited: Boolean
+    yearLevel: String
+    academicProgram: String
     group: Group
     student: User
     show: Show
@@ -102,6 +106,8 @@ type Video implements Entry {
     comment: String
     forSale: Boolean
     invited: Boolean
+    yearLevel: String
+    academicProgram: String
 }
 
 type OtherMedia implements Entry {
@@ -114,6 +120,8 @@ type OtherMedia implements Entry {
     moreCopies: Boolean
     forSale: Boolean
     invited: Boolean
+    yearLevel: String
+    academicProgram: String
 }
 
 enum UserType {

--- a/backend/schema.js
+++ b/backend/schema.js
@@ -67,34 +67,57 @@ type Vote {
     entry: Entry
 }
 
-
 interface Entry {
     id: ID!
     group: Group
     student: User
     show: Show
+    title: String
     comment: String
     forSale: Boolean
     invited: Boolean
     yearLevel: String
     academicProgram: String
+    moreCopies: Boolean    
+}
+
+input EntryInput {
+    groupId: Int
+    studentUsername: String
+    showId: Int!
+    title: String!
+    comment: String
+    forSale: Boolean
+    yearLevel: String
+    academicProgram: String
+    moreCopies: Boolean
 }
 
 type Photo implements Entry {
     id: ID!
-    path: String
-    horizDimInch: Float
-    vertDimInch: Float
+    group: Group
+    student: User
+    show: Show
+    title: String
     comment: String
-    media: String
-    moreCopies: Boolean
     forSale: Boolean
     invited: Boolean
     yearLevel: String
     academicProgram: String
-    group: Group
-    student: User
-    show: Show
+    moreCopies: Boolean
+    
+    path: String
+    horizDimInch: Float
+    vertDimInch: Float
+    mediaType: String
+}
+
+input PhotoInput {
+    entry: EntryInput
+    path: String!
+    horizDimInch: Float!
+    vertDimInch: Float!
+    mediaType: String
 }
 
 type Video implements Entry {
@@ -102,12 +125,15 @@ type Video implements Entry {
     group: Group
     student: User
     show: Show
-    videoURL: String
+    title: String
     comment: String
     forSale: Boolean
     invited: Boolean
     yearLevel: String
     academicProgram: String
+    moreCopies: Boolean
+    
+    videoURL: String
 }
 
 type OtherMedia implements Entry {
@@ -115,13 +141,16 @@ type OtherMedia implements Entry {
     group: Group
     student: User
     show: Show
-    photoPath: String
+    title: String
     comment: String
-    moreCopies: Boolean
     forSale: Boolean
     invited: Boolean
     yearLevel: String
     academicProgram: String
+    moreCopies: Boolean
+    
+    photoPath: String
+    moreCopies: Boolean
 }
 
 enum UserType {
@@ -160,6 +189,7 @@ type Mutation {
     assignToShow(showId: ID!, usernames: [String]!): Boolean    
     removeFromShow(showId: ID!, usernames: [String]!): Boolean    
     
+    createPhoto(input: PhotoInput!): Photo
 }
 
 enum SortDirection {

--- a/backend/test/factories.js
+++ b/backend/test/factories.js
@@ -2,8 +2,8 @@ import faker from 'faker'
 import User from '../models/user'
 import Show from '../models/show'
 import Image from '../models/image'
-import Entry, { IMAGE_ENTRY, VIDEO_ENTRY, OTHER_ENTRY } from '../models/entry'
-import { STUDENT } from '../permissionLevels'
+import Entry from '../models/entry'
+import { STUDENT, IMAGE_ENTRY, VIDEO_ENTRY, OTHER_ENTRY } from '../constants'
 
 /**
  * Fake a User
@@ -68,6 +68,8 @@ function fakeEntry (opts) {
   opts.forSale = opts.forSale === undefined ? faker.random.boolean() : opts.forSale
   opts.invited = opts.invited === undefined ? faker.random.boolean() : opts.invited
   opts.awardWon = opts.awardWon || faker.lorem.words(2)
+  opts.yearLevel = opts.yearLevel === undefined ? faker.lorem.word() : opts.yearLevel
+  opts.academicProgram = opts.academicProgram === undefined ? faker.lorem.word() : opts.academicProgram
   const showPromise = opts.show ? Promise.resolve(opts.show) : fakeShow()
   const userPromise = opts.user || opts.group ? Promise.resolve(opts.user) : fakeUser()
   const entryType = opts.image ? IMAGE_ENTRY : opts.video ? VIDEO_ENTRY : OTHER_ENTRY

--- a/backend/test/factories.js
+++ b/backend/test/factories.js
@@ -33,6 +33,7 @@ export function fakeShow (opts) {
   opts.entryEnd = opts.entryEnd || faker.date.between('2015-01-03', '2015-01-04')
   opts.judgingStart = opts.judgingStart || faker.date.between('2015-01-05', '2015-01-06')
   opts.judgingEnd = opts.judgingEnd || faker.date.between('2015-01-07', '2015-01-08')
+  opts.moreCopies = opts.moreCopies === undefined ? faker.random.boolean() : opts.moreCopies
   return Show.create({
     name: opts.name,
     description: opts.description,
@@ -40,7 +41,8 @@ export function fakeShow (opts) {
     entryStart: opts.entryStart,
     entryEnd: opts.entryEnd,
     judgingStart: opts.judgingStart,
-    judgingEnd: opts.judgingEnd
+    judgingEnd: opts.judgingEnd,
+    moreCopies: opts.moreCopies
   })
 }
 
@@ -48,12 +50,12 @@ function fakeImage (opts) {
   opts.path = opts.path || faker.system.commonFileName('.jpg')
   opts.horizDimInch = opts.horizDimInch || faker.random.number({min: 1, max: 100})
   opts.vertDimInch = opts.vertDimInch || faker.random.number({min: 1, max: 100})
-  opts.media = opts.media || faker.lorem.word()
+  opts.mediaType = opts.mediaType || faker.lorem.word()
   return Image.create({
     path: opts.path,
     horizDimInch: opts.horizDimInch,
     vertDimInch: opts.vertDimInch,
-    mediaType: opts.media
+    mediaType: opts.mediaType
   })
 }
 

--- a/backend/test/factories.js
+++ b/backend/test/factories.js
@@ -34,6 +34,7 @@ export function fakeShow (opts) {
   opts.judgingStart = opts.judgingStart || faker.date.between('2015-01-05', '2015-01-06')
   opts.judgingEnd = opts.judgingEnd || faker.date.between('2015-01-07', '2015-01-08')
   opts.moreCopies = opts.moreCopies === undefined ? faker.random.boolean() : opts.moreCopies
+  opts.excludeFromJudging = opts.excludeFromJudging === undefined ? faker.random.boolean() : opts.excludeFromJudging
   return Show.create({
     name: opts.name,
     description: opts.description,
@@ -42,7 +43,8 @@ export function fakeShow (opts) {
     entryEnd: opts.entryEnd,
     judgingStart: opts.judgingStart,
     judgingEnd: opts.judgingEnd,
-    moreCopies: opts.moreCopies
+    moreCopies: opts.moreCopies,
+    excludeFromJudging: opts.excludeFromJudging
   })
 }
 

--- a/backend/test/resolvers/entry.js
+++ b/backend/test/resolvers/entry.js
@@ -1,0 +1,146 @@
+import Entry from '../../models/entry'
+import { expect } from 'chai'
+import { createPhoto } from '../../resolvers/mutations/entry'
+import { fakeUser, fakeShow } from '../factories'
+
+describe('Entry Mutations', function () {
+  describe('Image Creation', function () {
+    describe('Successes', function () {
+      it('accepts a standard Entry', function () {
+        return Promise.all([fakeUser(), fakeShow()])
+          .then((models) => {
+            const user = models[0]
+            const show = models[1]
+            const args = {
+              input: {
+                entry: {
+                  studentUsername: user.username,
+                  showId: show.id,
+                  title: 'mytitle',
+                  comment: 'this is my comment',
+                  forSale: false,
+                  yearLevel: 'second',
+                  academicProgram: 'learning',
+                  moreCopies: false
+                },
+                path: 'a/path.jpg',
+                horizDimInch: 1.2,
+                vertDimInch: 1.3,
+                mediaType: 'mymedia'
+              }
+            }
+            return createPhoto({}, args, {auth: {type: 'ADMIN'}})
+              .then(() => {
+                // make sure an Entry was created
+                return Entry.count().then((num) => expect(num).to.equal(1))
+              })
+          })
+      })
+    })
+    describe('Validation Failures', function () {
+      it('rejects non-admins making an entry for someone other than themself', function () {
+        const args = {
+          input: {
+            entry: {
+              studentUsername: 'user2',
+              showId: 1,
+              title: 'mytitle',
+              comment: 'this is my comment',
+              forSale: false,
+              yearLevel: 'second',
+              academicProgram: 'learning',
+              moreCopies: false
+            },
+            path: 'a/path.jpg',
+            horizDimInch: 1.2,
+            vertDimInch: 1.3,
+            mediaType: 'mymedia'
+          }
+        }
+        expect(() => {
+          createPhoto({}, args, {auth: {type: 'STUDENT', username: 'user1'}})
+        }).to.throw('Permission Denied')
+      })
+
+      it('rejects images with invalid dimensions', function () {
+        const args = {
+          input: {
+            entry: {
+              studentUsername: 'user1',
+              showId: 1,
+              title: 'mytitle',
+              comment: 'this is my comment',
+              forSale: false,
+              yearLevel: 'second',
+              academicProgram: 'learning',
+              moreCopies: false
+            },
+            path: 'a/path.jpg',
+            horizDimInch: -1.2,
+            vertDimInch: -1.3,
+            mediaType: 'mymedia'
+          }
+        }
+        return createPhoto({}, args, {auth: {type: 'STUDENT', username: 'user1'}})
+          .then(() => Promise.reject(new Error('should have rejected')))
+          .catch((e) => {
+            expect(e.message).to.match(/must be positive/)
+            return Promise.resolve()
+          })
+      })
+
+      it('rejects non-existent show ids', function () {
+        const args = {
+          input: {
+            entry: {
+              studentUsername: 'user1',
+              showId: 1,
+              title: 'mytitle',
+              comment: 'this is my comment',
+              forSale: false,
+              yearLevel: 'second',
+              academicProgram: 'learning',
+              moreCopies: false
+            },
+            path: 'a/path.jpg',
+            horizDimInch: 1.2,
+            vertDimInch: 1.3,
+            mediaType: 'mymedia'
+          }
+        }
+        return createPhoto({}, args, {auth: {type: 'STUDENT', username: 'user1'}})
+          .then(() => Promise.reject(new Error('should have rejected')))
+          .catch((e) => {
+            expect(e.message).to.not.equal('should have rejected')
+            return Promise.resolve()
+          })
+      })
+
+      it('rejects entries with neither username nor group set', function () {
+        const args = {
+          input: {
+            entry: {
+              showId: 1,
+              title: 'mytitle',
+              comment: 'this is my comment',
+              forSale: false,
+              yearLevel: 'second',
+              academicProgram: 'learning',
+              moreCopies: false
+            },
+            path: 'a/path.jpg',
+            horizDimInch: 1.2,
+            vertDimInch: 1.3,
+            mediaType: 'mymedia'
+          }
+        }
+        return createPhoto({}, args, {auth: {type: 'ADMIN'}})
+          .then(() => Promise.reject(new Error('should have rejected')))
+          .catch((e) => {
+            expect(e.message).to.match(/Entry must have an entrant/)
+            return Promise.resolve()
+          })
+      })
+    })
+  })
+})

--- a/backend/test/resolvers/entryQuery.js
+++ b/backend/test/resolvers/entryQuery.js
@@ -1,7 +1,6 @@
 /* eslint-disable no-unused-expressions */
 
 import { expect } from 'chai'
-import Entry from '../../models/entry'
 import { entries } from '../../resolvers/queries/entryQuery'
 import { fakeImageEntry } from '../factories'
 

--- a/backend/test/resolvers/entryQuery.js
+++ b/backend/test/resolvers/entryQuery.js
@@ -1,0 +1,60 @@
+/* eslint-disable no-unused-expressions */
+
+import { expect } from 'chai'
+import Entry from '../../models/entry'
+import { entries } from '../../resolvers/queries/entryQuery'
+import { fakeImageEntry } from '../factories'
+
+describe('Entry Queries', function () {
+  describe('Entries Query', function () {
+    it('Rejects non-admins', function () {
+      expect(() => entries('', {}, {auth: {type: 'STUDENT'}}))
+        .to.throw('Permission Denied')
+    })
+    it('Gets an empty list when no entries exist', function () {
+      return entries('', {}, {auth: {type: 'ADMIN'}})
+        .then((entries) => {
+          expect(entries).to.be.length(0)
+        })
+    })
+    it('Gets an entry when it exists', function () {
+      return fakeImageEntry({horizDimInch: 3, vertDimInch: 4})
+        .then((entry) => {
+          return entries('', {}, {auth: {type: 'ADMIN'}})
+            .then((resultEntries) => {
+              expect(resultEntries).to.be.length(1)
+              expect(resultEntries[0].id).to.equal(entry.id)
+              expect(resultEntries[0].title).to.equal(entry.title)
+              expect(resultEntries[0].horizDimInch).to.equal(3)
+              expect(resultEntries[0].vertDimInch).to.equal(4)
+            })
+        })
+    })
+    it('Gets two entries when multiple exist', function () {
+      return Promise.all([fakeImageEntry(), fakeImageEntry()])
+        .then(originalEntries => {
+          originalEntries = originalEntries.sort((a, b) => a.id - b.id)
+          const entry1 = originalEntries[0]
+          const entry2 = originalEntries[1]
+          return entries('', {}, {auth: {type: 'ADMIN'}})
+            .then((resultEntries) => {
+              expect(resultEntries).to.be.length(2)
+              resultEntries = resultEntries.sort((a, b) => a.id - b.id)
+              expect(resultEntries[0].id).to.equal(entry1.id)
+              expect(resultEntries[1].id).to.equal(entry2.id)
+            })
+        })
+    })
+    it('Can limit to a certain show', function () {
+      return Promise.all([fakeImageEntry(), fakeImageEntry()])
+        .then(originalEntries => {
+          expect(originalEntries[0].showId).to.not.equal(originalEntries[1].showId)
+          return entries('', {showId: originalEntries[0].showId}, {auth: {type: 'ADMIN'}})
+            .then((resultEntries) => {
+              expect(resultEntries).to.be.length(1)
+              expect(resultEntries[0].id).to.equal(originalEntries[0].id)
+            })
+        })
+    })
+  })
+})

--- a/backend/test/resolvers/judge.js
+++ b/backend/test/resolvers/judge.js
@@ -7,19 +7,6 @@ import { createJudge, updatePermissions } from '../../resolvers/mutations/judge'
 import { fakeUser } from '../factories'
 
 describe('Judge Resolvers', function () {
-  beforeEach(function (done) {
-    db.sync({force: true}).then(() => {
-      User
-        .destroy({where: {}})
-        .then(() => done())
-    })
-  })
-  afterEach(function (done) {
-    User
-      .destroy({where: {}})
-      .then(() => done())
-  })
-
   describe('Judge Creation Resolver', function () {
     it('Does not allow duplicate usernames', function (done) {
       fakeUser({type: 'ADMIN'})

--- a/backend/test/resolvers/show.js
+++ b/backend/test/resolvers/show.js
@@ -7,18 +7,6 @@ import { createShow, assignToShow, removeFromShow } from '../../resolvers/mutati
 import { fakeShow, fakeUser } from '../factories'
 
 describe('Show Resolvers', function () {
-  beforeEach(function (done) {
-    db.sync({force: true}).then(() => {
-      Show
-        .destroy({where: {}})
-        .then(() => done())
-    })
-  })
-  afterEach(function (done) {
-    Show
-      .destroy({where: {}})
-      .then(() => done())
-  })
   describe('Create a show', function () {
     it('Does not allow null values', function (done) {
       createShow('', {}, {auth: {type: 'ADMIN'}})

--- a/backend/test/resolvers/showQuery.js
+++ b/backend/test/resolvers/showQuery.js
@@ -7,19 +7,6 @@ import { show, shows } from '../../resolvers/queries/showQuery'
 import { fakeShow } from '../factories'
 
 describe('Show Queries', function () {
-  beforeEach(function (done) {
-    db.sync({force: true}).then(() => {
-      Show
-        .destroy({where: {}})
-        .then(() => done())
-    })
-  })
-  afterEach(function (done) {
-    Show
-      .destroy({where: {}})
-      .then(() => done())
-  })
-
   describe('Show query', function () {
     it('Finds a show given the id', function (done) {
       fakeShow().then((s) => {

--- a/backend/test/resolvers/userQuery.js
+++ b/backend/test/resolvers/userQuery.js
@@ -8,19 +8,6 @@ import { fakeUser } from '../factories'
 import { STUDENT, JUDGE, ADMIN } from '../../permissionLevels'
 
 describe('User Queries', function () {
-  beforeEach(function (done) {
-    db.sync({force: true}).then(() => {
-      User
-        .destroy({where: {}})
-        .then(() => done())
-    })
-  })
-  afterEach(function (done) {
-    User
-      .destroy({where: {}})
-      .then(() => done())
-  })
-
   describe('User query', function () {
     it('Allows users to find themeselves', function (done) {
       fakeUser({username: 'user1'}).then((u) => {

--- a/backend/test/resolvers/userQuery.js
+++ b/backend/test/resolvers/userQuery.js
@@ -5,7 +5,7 @@ import db from '../../config/sequelize'
 import User from '../../models/user'
 import { user, users } from '../../resolvers/queries/userQuery'
 import { fakeUser } from '../factories'
-import { STUDENT, JUDGE, ADMIN } from '../../permissionLevels'
+import { STUDENT, JUDGE, ADMIN } from '../../constants'
 
 describe('User Queries', function () {
   describe('User query', function () {

--- a/backend/test/routes/auth.js
+++ b/backend/test/routes/auth.js
@@ -8,20 +8,6 @@ import { fakeUser } from '../factories'
 import { decodeUserToken } from '../util'
 
 describe('Authentication', () => {
-  beforeEach(function (done) {
-    db.sync({force: true}).then(() => {
-      User
-        .destroy({where: {}})
-        .then(() => done())
-    })
-  })
-
-  afterEach(function (done) {
-    User
-      .destroy({where: {}})
-      .then(() => done())
-  })
-
   describe('/auth/login', () => {
     it('redirects logged-out users to SAML endpoint', (done) => {
       request(server)

--- a/backend/test/routes/index.js
+++ b/backend/test/routes/index.js
@@ -17,20 +17,6 @@ describe('API Routes', function () {
   })
 
   describe('Simple GraphQL auth', function () {
-    beforeEach(function (done) {
-      db.sync({force: true}).then(() => {
-        User
-          .destroy({where: {}})
-          .then(() => done())
-      })
-    })
-
-    afterEach(function (done) {
-      User
-        .destroy({where: {}})
-        .then(() => done())
-    })
-
     it('rejects getting all users when not logged in', function (done) {
       request(server)
         .post('/graphql')

--- a/backend/test/setup.js
+++ b/backend/test/setup.js
@@ -1,5 +1,29 @@
+import User from '../models/user'
+import Show from '../models/show'
+import Entry from '../models/entry'
+import Group from '../models/group'
+import Image from '../models/image'
 import db from '../config/sequelize'
 
-after(function (done) {
-  db.close().then(() => done())
+before(function () {
+  return db.sync({force: true})
+})
+
+beforeEach(function () {
+  return db.transaction((t) => {
+    return db.query('SET FOREIGN_KEY_CHECKS = 0', {transaction: t})
+      .then(() => {
+        return Promise.all(
+          [User, Show, Entry, Group, Image]
+            .map((model) => model.destroy({where: {}, transaction: t}))
+        )
+      })
+      .then(() => {
+        return db.query('SET FOREIGN_KEY_CHECKS = 1', {transaction: t})
+      })
+  })
+})
+
+after(function () {
+  return db.close()
 })


### PR DESCRIPTION
Adds a query resolver for an entry. This is accomplished by:

* Adding `Group` model with attributes `id`, and `name`
* Adding `Image` model with attributes `id`, `path`, `horizDimInch`, `vertDimInch`, and `mediaType`
* Adding `Entry` model with a whole lot of attributes (see code)
* Adding a `fakeImageEntry(opts)` method for testing

Also included, major test speadup by changing how models are cleaned up after use.

Suite execution time decreated from 40s to 2s (!!!)