### PR TITLE
Config changes to remove sequelize operators deprecation warning and adding npm config to run single test

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -15,3 +15,4 @@
 - To migrate the database: `npm run migrate`
 - To seed the database: `npm run seed`
 - To run tests: `npm run test`
+- To run single test file:  `npm run test-file 'test/[path to file]`

--- a/backend/config/database.js
+++ b/backend/config/database.js
@@ -1,9 +1,12 @@
 import config from './index'
+import Sequelize from 'sequelize'
 
 const DB = config.get('ABSTRACTION_DB_NAME')
 const USER = config.get('ABSTRACTION_DB_USER')
 const PASSWORD = config.get('ABSTRACTION_DB_PASS')
 const HOST = config.get('ABSTRACTION_DB_HOST')
+
+const Op = Sequelize.Op;
 
 const development = {
   dialect: 'mysql',
@@ -11,7 +14,9 @@ const development = {
   database: DB,
   username: USER,
   password: PASSWORD,
-  port: 3306
+  port: 3306,
+  operatorAliases: Op
+
 }
 
 const test = {
@@ -21,7 +26,43 @@ const test = {
   username: USER,
   password: PASSWORD,
   port: 3306,
-  logging: false
+  logging: false,
+  operatorsAliases: {
+    $eq: Op.eq,
+    $ne: Op.ne,
+    $gte: Op.gte,
+    $gt: Op.gt,
+    $lte: Op.lte,
+    $lt: Op.lt,
+    $not: Op.not,
+    $in: Op.in,
+    $notIn: Op.notIn,
+    $is: Op.is,
+    $like: Op.like,
+    $notLike: Op.notLike,
+    $iLike: Op.iLike,
+    $notILike: Op.notILike,
+    $regexp: Op.regexp,
+    $notRegexp: Op.notRegexp,
+    $iRegexp: Op.iRegexp,
+    $notIRegexp: Op.notIRegexp,
+    $between: Op.between,
+    $notBetween: Op.notBetween,
+    $overlap: Op.overlap,
+    $contains: Op.contains,
+    $contained: Op.contained,
+    $adjacent: Op.adjacent,
+    $strictLeft: Op.strictLeft,
+    $strictRight: Op.strictRight,
+    $noExtendRight: Op.noExtendRight,
+    $noExtendLeft: Op.noExtendLeft,
+    $and: Op.and,
+    $or: Op.or,
+    $any: Op.any,
+    $all: Op.all,
+    $values: Op.values,
+    $col: Op.col
+  }
 }
 
 // Additonal exports so that sequelize-cli can read this config properly

--- a/backend/config/database.js
+++ b/backend/config/database.js
@@ -7,6 +7,42 @@ const PASSWORD = config.get('ABSTRACTION_DB_PASS')
 const HOST = config.get('ABSTRACTION_DB_HOST')
 
 const Op = Sequelize.Op;
+const operatorAliases =  {
+  $eq: Op.eq,
+  $ne: Op.ne,
+  $gte: Op.gte,
+  $gt: Op.gt,
+  $lte: Op.lte,
+  $lt: Op.lt,
+  $not: Op.not,
+  $in: Op.in,
+  $notIn: Op.notIn,
+  $is: Op.is,
+  $like: Op.like,
+  $notLike: Op.notLike,
+  $iLike: Op.iLike,
+  $notILike: Op.notILike,
+  $regexp: Op.regexp,
+  $notRegexp: Op.notRegexp,
+  $iRegexp: Op.iRegexp,
+  $notIRegexp: Op.notIRegexp,
+  $between: Op.between,
+  $notBetween: Op.notBetween,
+  $overlap: Op.overlap,
+  $contains: Op.contains,
+  $contained: Op.contained,
+  $adjacent: Op.adjacent,
+  $strictLeft: Op.strictLeft,
+  $strictRight: Op.strictRight,
+  $noExtendRight: Op.noExtendRight,
+  $noExtendLeft: Op.noExtendLeft,
+  $and: Op.and,
+  $or: Op.or,
+  $any: Op.any,
+  $all: Op.all,
+  $values: Op.values,
+  $col: Op.col
+}
 
 const development = {
   dialect: 'mysql',
@@ -15,8 +51,7 @@ const development = {
   username: USER,
   password: PASSWORD,
   port: 3306,
-  operatorAliases: Op
-
+  operatorAliases: operatorAliases
 }
 
 const test = {
@@ -27,42 +62,7 @@ const test = {
   password: PASSWORD,
   port: 3306,
   logging: false,
-  operatorsAliases: {
-    $eq: Op.eq,
-    $ne: Op.ne,
-    $gte: Op.gte,
-    $gt: Op.gt,
-    $lte: Op.lte,
-    $lt: Op.lt,
-    $not: Op.not,
-    $in: Op.in,
-    $notIn: Op.notIn,
-    $is: Op.is,
-    $like: Op.like,
-    $notLike: Op.notLike,
-    $iLike: Op.iLike,
-    $notILike: Op.notILike,
-    $regexp: Op.regexp,
-    $notRegexp: Op.notRegexp,
-    $iRegexp: Op.iRegexp,
-    $notIRegexp: Op.notIRegexp,
-    $between: Op.between,
-    $notBetween: Op.notBetween,
-    $overlap: Op.overlap,
-    $contains: Op.contains,
-    $contained: Op.contained,
-    $adjacent: Op.adjacent,
-    $strictLeft: Op.strictLeft,
-    $strictRight: Op.strictRight,
-    $noExtendRight: Op.noExtendRight,
-    $noExtendLeft: Op.noExtendLeft,
-    $and: Op.and,
-    $or: Op.or,
-    $any: Op.any,
-    $all: Op.all,
-    $values: Op.values,
-    $col: Op.col
-  }
+  operatorsAliases: operatorAliases
 }
 
 // Additonal exports so that sequelize-cli can read this config properly

--- a/backend/package.json
+++ b/backend/package.json
@@ -18,6 +18,7 @@
   "scripts": {
     "start": "nodemon ./bin/www --exec babel-node",
     "test": "cross-env NODE_ENV=test nyc mocha --timeout 5000 test/setup.js test/**/*.js",
+    "test-file": "cross-env NODE_ENV=test nyc mocha test/setup.js",
     "bootstrap": "babel-node ./bootstrap.js",
     "keygen": "babel-node keygen",
     "sequelize": "babel-node ./node_modules/.bin/sequelize",


### PR DESCRIPTION
Tests are run on a file with the following command style:
` npm run test-file test/routes/auth.js`

Note that the path from 'test/' is needed.