### PR TITLE
Adds new Group schema for freeform participants

### DIFF
--- a/backend/db/migrations/20171116200117-create-group.js
+++ b/backend/db/migrations/20171116200117-create-group.js
@@ -22,5 +22,5 @@ export function up (queryInterface, Sequelize) {
 }
 
 export function down (queryInterface) {
-  return queryInterface.dropTable('group')
+  return queryInterface.dropTable('groups')
 }

--- a/backend/db/migrations/20180122205100-modify-group.js
+++ b/backend/db/migrations/20180122205100-modify-group.js
@@ -1,0 +1,29 @@
+export function up (queryInterface, Sequelize) {
+  return queryInterface.addColumn(
+    'groups',
+    'participants',
+    {
+      allowNull: false,
+      type: Sequelize.STRING
+    }
+  ).then(() => {
+    queryInterface.addColumn(
+      'groups',
+      'creatorUsername',
+      {
+        type: Sequelize.STRING,
+        references: {
+          model: 'users',
+          key: 'username'
+        },
+        onUpdate: 'cascade',
+        onDelete: 'cascade'
+      }
+    )
+  })
+}
+
+export function down (queryInterface) {
+  return queryInterface.removeColumn('groups', 'participants')
+    .then(() => queryInterface.removeColumn('groups', 'creatorUsername'))
+}

--- a/backend/helpers/submission.js
+++ b/backend/helpers/submission.js
@@ -1,6 +1,17 @@
 export function allowedToSubmit (args, req) {
-  // TODO update the below to account for group submission rights
-  return req.auth.username !== undefined && req.auth.username === args.input.entry.studentUsername
+  if (req.auth.username === undefined) {
+    // this seems ... odd
+    return false
+  } else if (args.input.entry.studentUsername) {
+    // if submitting individually, ensure you submit your own
+    return req.auth.username === args.input.entry.studentUsername
+  } else if (args.input.entry.group.creatorUsername) {
+    // if submitting as a group, ensure that you are the creator
+    return req.auth.username === args.input.entry.group.creatorUsername
+  } else {
+    // dunno what this is, might as well deny it
+    return false
+  }
 }
 
 export function parseVideo (url) {

--- a/backend/models/entry.js
+++ b/backend/models/entry.js
@@ -1,6 +1,7 @@
 import Image from './image'
 import Video from './video'
 import Other from './other'
+import Group from './group'
 import DataTypes from 'sequelize'
 import sequelize from '../config/sequelize'
 import { IMAGE_ENTRY, VIDEO_ENTRY, OTHER_ENTRY } from '../constants'
@@ -103,6 +104,14 @@ Entry.prototype.getOther = function getOther () {
     return Promise.resolve(null)
   }
   return Other.findOne({ where: {id: this.entryId} })
+}
+
+Entry.prototype.getGroup = function getGroup () {
+  if (this.groupId === null || this.groupId === undefined) {
+    // the above oddness is due to the fact that groupId == 0 is valid
+    return Promise.resolve(null)
+  }
+  return Group.findById(this.groupId)
 }
 
 export default Entry

--- a/backend/models/group.js
+++ b/backend/models/group.js
@@ -1,17 +1,39 @@
 import DataTypes from 'sequelize'
 import sequelize from '../config/sequelize'
 
-export default sequelize.define('group', {
-  createdAt: {
-    allowNull: false,
-    type: DataTypes.DATE
-  },
+import User from './user'
+
+const Group = sequelize.define('group', {
   name: {
     allowNull: false,
     type: DataTypes.STRING
+  },
+  creatorUsername: {
+    allowNull: false,
+    type: DataTypes.STRING
+  },
+  participants: {
+    allowNull: false,
+    type: DataTypes.STRING
+  },
+  createdAt: {
+    allowNull: false,
+    type: DataTypes.DATE
   },
   updatedAt: {
     allowNull: false,
     type: DataTypes.DATE
   }
 })
+
+/**
+ * Gets the creator of this group as a Promise
+ */
+Group.prototype.getCreator = function getCreator () {
+  if (!this.creatorUsername) {
+    return Promise.resolve(null)
+  }
+  return User.findById(this.creatorUsername)
+}
+
+export default Group

--- a/backend/models/image.js
+++ b/backend/models/image.js
@@ -21,6 +21,14 @@ export default sequelize.define('image', {
     type: DataTypes.STRING,
     allowNull: false,
     notEmpty: true
+  },
+  createdAt: {
+    allowNull: false,
+    type: DataTypes.DATE
+  },
+  updatedAt: {
+    allowNull: false,
+    type: DataTypes.DATE
   }
 },
 {

--- a/backend/models/other.js
+++ b/backend/models/other.js
@@ -7,6 +7,14 @@ export default sequelize.define('other', {
   path: {
     type: DataTypes.STRING,
     allowNull: true
+  },
+  createdAt: {
+    allowNull: false,
+    type: DataTypes.DATE
+  },
+  updatedAt: {
+    allowNull: false,
+    type: DataTypes.DATE
   }
 },
 {

--- a/backend/models/video.js
+++ b/backend/models/video.js
@@ -13,6 +13,14 @@ export default sequelize.define('video', {
     type: DataTypes.STRING,
     allowNull: false,
     notEmpty: true
+  },
+  createdAt: {
+    allowNull: false,
+    type: DataTypes.DATE
+  },
+  updatedAt: {
+    allowNull: false,
+    type: DataTypes.DATE
   }
 },
 {

--- a/backend/resolvers/index.js
+++ b/backend/resolvers/index.js
@@ -1,6 +1,7 @@
 import Entry from './types/entryType'
 import User from './types/userType'
 import DateScalar from './types/dateScalar'
+import Group from './types/groupType'
 import Show from './types/showType'
 import * as EntryMutations from './mutations/entry'
 import * as EntryQuery from './queries/entryQuery'
@@ -13,6 +14,7 @@ export default {
   ...Entry,
   ...User,
   ...DateScalar,
+  ...Group,
   ...Show,
   Query: {
     ...EntryQuery,

--- a/backend/resolvers/mutations/entry.js
+++ b/backend/resolvers/mutations/entry.js
@@ -22,9 +22,17 @@ const createEntry = (entry, entryType, entryId, t) => {
   }
   return groupPromise
     .then(group => {
-      // remove the `group` attribute and replace it with the `groupId`
+      // We now have access to a Group instance (from attributes above).
+      // The only thing left to do is create the Entry object, which is (mostly)
+      // described by the `entry` parameter. We must first remove its `group`
+      // property and replace it with the group's ID, since our orm recognizes
+      // groupId, not a Group
+
+      // clone the object
       let newEntry = Object.assign({}, entry)
+      // remove the 'group' property
       delete newEntry['group']
+      // create the new Entry with select properties filled-in
       return Entry.create({
         ...newEntry,
         entryType: entryType,

--- a/backend/resolvers/queries/userQuery.js
+++ b/backend/resolvers/queries/userQuery.js
@@ -3,7 +3,7 @@ import { UserError } from 'graphql-errors'
 import { STUDENT, ADMIN, JUDGE } from '../../constants'
 
 export function user (_, args, req) {
-  const isRequestingOwnUser = req.auth.id !== undefined && req.auth.id === args.id
+  const isRequestingOwnUser = req.auth.username !== undefined && req.auth.username === args.id
   if (req.auth.type !== ADMIN && !isRequestingOwnUser) {
     throw new UserError('Permission Denied')
   }

--- a/backend/resolvers/types/entryType.js
+++ b/backend/resolvers/types/entryType.js
@@ -2,6 +2,9 @@ import { IMAGE_ENTRY, VIDEO_ENTRY, OTHER_ENTRY } from '../../constants'
 
 export default {
   Entry: {
+    group (entry) {
+      return entry.getGroup()
+    },
     __resolveType (data, context, info) {
       if (data.entryType === IMAGE_ENTRY) {
         return info.schema.getType('Photo')

--- a/backend/resolvers/types/groupType.js
+++ b/backend/resolvers/types/groupType.js
@@ -1,0 +1,7 @@
+export default {
+  Group: {
+    creator (group) {
+      return group.getCreator()
+    }
+  }
+}

--- a/backend/schema.js
+++ b/backend/schema.js
@@ -32,8 +32,15 @@ input PermissionInput {
 
 type Group {
     id: ID!
-    name: String
-    students: [User]
+    name: String!
+    creator: User!
+    participants: String!
+}
+
+input GroupInput {
+    name: String!
+    creatorUsername: String!
+    participants: String!
 }
 
 type Show {
@@ -82,7 +89,7 @@ interface Entry {
 }
 
 input EntryInput {
-    groupId: Int
+    group: GroupInput
     studentUsername: String
     showId: Int!
     title: String!

--- a/backend/test/resolvers/judge.js
+++ b/backend/test/resolvers/judge.js
@@ -7,6 +7,11 @@ import { fakeUser } from '../factories'
 
 describe('Judge Resolvers', function () {
   describe('Judge Creation Resolver', function () {
+    it('Does now allow non-admins to add judge', function () {
+      expect(() =>
+        createJudge('', {}, {auth: {type: 'STUDENT', username: 'billy'}})
+      ).to.throw(/Permission Denied/)
+    })
     it('Does not allow duplicate usernames', function (done) {
       fakeUser({type: 'ADMIN'})
         .then((me) => {
@@ -52,6 +57,22 @@ describe('Judge Resolvers', function () {
   })
 
   describe('Update Permissions Resolver', function () {
+    it('Does now allow non-admins to update permissions', function () {
+      expect(() =>
+        updatePermissions('', {}, {auth: {type: 'STUDENT', username: 'billy'}})
+      ).to.throw(/Permission Denied/)
+    })
+
+    it('Fails with non-existent users', function () {
+      return updatePermissions(
+        '',
+        {input: {username: 'comeonandslam'}},
+        {auth: {type: 'ADMIN'}}
+      )
+        .then(() => { throw new Error('should have rejected promise') })
+        .catch((e) => expect(e.message).to.match(/User Not Found/))
+    })
+
     it('Changes a Student to a Judge', function (done) {
       const input = {input: {
         username: 'user3'

--- a/backend/test/resolvers/show.js
+++ b/backend/test/resolvers/show.js
@@ -7,6 +7,11 @@ import { fakeShow, fakeUser } from '../factories'
 
 describe('Show Resolvers', function () {
   describe('Create a show', function () {
+    it('Does not allow non-admins', function () {
+      expect(() =>
+        createShow('', {}, {auth: {type: 'STUDENT', username: 'billy'}})
+      ).to.throw(/Permission Denied/)
+    })
     it('Does not allow null values', function (done) {
       createShow('', {}, {auth: {type: 'ADMIN'}})
         .catch((err) => {
@@ -51,6 +56,11 @@ describe('Show Resolvers', function () {
     })
   })
   describe('Assign to show', function () {
+    it('Does not allow non-admins', function () {
+      expect(() =>
+        assignToShow('', {}, {auth: {type: 'STUDENT', username: 'billy'}})
+      ).to.throw(/Permission Denied/)
+    })
     it('Notifies when show does not exist', function (done) {
       const input = {show: 50, usernames: ['user1']}
       assignToShow('', input, {auth: {type: 'ADMIN'}})
@@ -97,6 +107,11 @@ describe('Show Resolvers', function () {
     })
   })
   describe('Unassign from show', function () {
+    it('Does not allow non-admins', function () {
+      expect(() =>
+        removeFromShow('', {}, {auth: {type: 'STUDENT', username: 'billy'}})
+      ).to.throw(/Permission Denied/)
+    })
     it('Notifies when show does not exist', function (done) {
       const input = {show: 50, usernames: ['user1']}
       removeFromShow('', input, {auth: {type: 'ADMIN'}})

--- a/backend/test/resolvers/userQuery.js
+++ b/backend/test/resolvers/userQuery.js
@@ -10,7 +10,7 @@ describe('User Queries', function () {
   describe('User query', function () {
     it('Allows users to find themeselves', function (done) {
       fakeUser({username: 'user1'}).then((u) => {
-        user('', {id: u.username}, {auth: {type: 'STUDENT', id: 'user1'}})
+        user('', {id: u.username}, {auth: {type: 'STUDENT', username: 'user1'}})
           .then((result) => {
             expect(result.username).to.equal(u.username)
             done()
@@ -20,7 +20,7 @@ describe('User Queries', function () {
     it('Does not allow non admins to find other users by username', function (done) {
       fakeUser({username: 'user1'}).then((u) => {
         expect(() => user('', {id: 'anotheruser'},
-          {auth: { type: 'STUDENT', id: 'user1' }})).to.throw(/Permission Denied/)
+          {auth: { type: 'STUDENT', username: 'user1' }})).to.throw(/Permission Denied/)
         done()
       })
     })


### PR DESCRIPTION
Changes the Group schema to allow participants to be added via a freeform text field.

Also modifies the submission mechanism to support automagically creating a group when submitting work.

Example mutation for submitting with a group:

```graphql
mutation {
  createPhoto(input:{
    entry: {
      group: {
        name:"my fun group",
        creatorUsername:"user1",
        participants:"uncle timmy"
      },
      showId: 1,
      title: "mytitle",
      comment: "this is my comment",
      forSale: false,
      yearLevel: "second",
      academicProgram: "learning",
      moreCopies: false
    },
    path:"foo.jpg",
    horizDimInch:3,
    vertDimInch:3,
    mediaType:"mymedia"
  }) {
    id
  }
}
```