### PR TITLE
fix heisenbug with apollo-client caching

### DIFF
--- a/frontend/config/apollo.js
+++ b/frontend/config/apollo.js
@@ -23,9 +23,9 @@ const client = new ApolloClient({
       switch (o.__typename) {
         case 'User':
           // The primary key of 'User' is 'username'
-          return o.username
+          return `User:${o.username}`
         default:
-          return o.id
+          return `${o.__typename}:${o.id}`
       }
     }
   })


### PR DESCRIPTION
This fixes an issue with apollo-client's caching and fetching system. Our current method of extracting object IDs does not also include the type of the object in its return value.

Consequently, apollo thinks that a show object of ID 1 is the same as the entry object of id 1. The only side-effect of this I have observed is that the `__typename` of an embedded Entry is occasionally `'Show'`, which is clearly incorrect.

This fixes the issue by prefixing an object's ID with its typename.