### PR TITLE
Adding assigned show cards for judges

### DIFF
--- a/backend/resolvers/queries/userQuery.js
+++ b/backend/resolvers/queries/userQuery.js
@@ -10,6 +10,13 @@ export function user (_, args, req) {
   return User.findById(args.id)
 }
 
+export function self(_, __,req) {
+  if (!req.auth.username){
+    throw new UserError('Permission Denied')
+  }
+  return User.findById(req.auth.username)
+}
+
 export function users (_, args, req) {
   if (req.auth.type !== ADMIN) {
     throw new UserError('Permission Denied')

--- a/backend/resolvers/types/userType.js
+++ b/backend/resolvers/types/userType.js
@@ -1,5 +1,6 @@
 export default {
   User: {
+    // TODO: Order shows
     shows (user) {
       return user.getShows()
     }

--- a/backend/resolvers/types/userType.js
+++ b/backend/resolvers/types/userType.js
@@ -1,8 +1,8 @@
 export default {
   User: {
-    // TODO: Order shows
+    // Judges (and Admins) have shows
     shows (user) {
-      return user.getShows()
+      return user.getShows({order: [['judgingStart', 'DESC']]})
     }
   }
 }

--- a/backend/schema.js
+++ b/backend/schema.js
@@ -190,6 +190,7 @@ enum UserType {
 }
 
 type Query {
+    self: User
     user(id: ID!): User
     users(type: UserType): [User]
     group(id: ID!): Group

--- a/frontend/src/Judge/components/ShowCard.js
+++ b/frontend/src/Judge/components/ShowCard.js
@@ -16,7 +16,6 @@ const ButtonContainer = styled.div`
   position: absolute;
   right: 0;
   bottom: 0;
-  width: '150px';
 `
 
 const ShowCard = props => (
@@ -35,6 +34,7 @@ const ShowCard = props => (
     <Col>
       <ButtonContainer>
         <Button
+          size='lg'
           style={{ cursor: 'pointer' }}
           tag={Link}
           to={`show/${props.id}/vote`}

--- a/frontend/src/Judge/components/ShowCard.js
+++ b/frontend/src/Judge/components/ShowCard.js
@@ -3,7 +3,7 @@ import styled from 'styled-components'
 import { Link } from 'react-router-dom'
 import PropTypes from 'prop-types'
 import Moment from 'react-moment'
-import { Button, ButtonGroup, Row, Col } from 'reactstrap'
+import { Button, Row, Col } from 'reactstrap'
 
 const Card = styled.div`
   background-color: #f8f9fa;
@@ -12,47 +12,44 @@ const Card = styled.div`
   padding: 10px;
   width: 100%;
 `
+const ButtonContainer = styled.div`
+  position: absolute;
+  right: 0;
+  bottom: 0;
+  width: '150px'
+`
 
 const ShowCard = props => (
   <Card>
     <h2>
       <Link to={`show/${props.id}`}>{props.name}</Link>
     </h2>
-    <Row>
-      <Col>
-        <dl>
-          <dt>Submission Starts:</dt>
-          <dd>
-            <Moment format='YYYY/MM/DD'>{props.entryStart}</Moment>
-          </dd>
-          <dt>Submission Ends:</dt>
-          <dd>
-            <Moment format='YYYY/MM/DD'>{props.entryEnd}</Moment>
-          </dd>
-        </dl>
-      </Col>
-      <Col>
-        <dl>
-          <dt>Judging Starts:</dt>
-          <dd>
-            <Moment format='YYYY/MM/DD'>{props.judgingStart}</Moment>
-          </dd>
-          <dt>Judging Ends:</dt>
-          <dd>
-            <Moment format='YYYY/MM/DD'>{props.judgingEnd}</Moment>
-          </dd>
-        </dl>
-      </Col>
-    </Row>
+    <Col>
+      <dl>
+        <dt>Judging Ends:</dt>
+        <dd>
+          <Moment format='YYYY/MM/DD'>{props.judgingEnd}</Moment>
+        </dd>
+      </dl>
+    </Col>
+    <Col>
+      <ButtonContainer>
+        <Button
+          style={{ cursor: 'pointer' }}
+          tag={Link}
+          to={`judge/vote`} // TODO: Figure out where they go to vote
+        // TODO: Conditionally change the text
+        >
+          Start
+    </Button>
+      </ButtonContainer>
+    </Col>
   </Card>
 )
 
 ShowCard.propTypes = {
   id: PropTypes.string.isRequired,
   name: PropTypes.string.isRequired,
-  entryStart: PropTypes.string.isRequired,
-  entryEnd: PropTypes.string.isRequired,
-  judgingStart: PropTypes.string.isRequired,
   judgingEnd: PropTypes.string.isRequired
 }
 

--- a/frontend/src/Judge/components/ShowCard.js
+++ b/frontend/src/Judge/components/ShowCard.js
@@ -1,0 +1,59 @@
+import React from 'react'
+import styled from 'styled-components'
+import { Link } from 'react-router-dom'
+import PropTypes from 'prop-types'
+import Moment from 'react-moment'
+import { Button, ButtonGroup, Row, Col } from 'reactstrap'
+
+const Card = styled.div`
+  background-color: #f8f9fa;
+  border-radius: 5px;
+  margin-top: 15px;
+  padding: 10px;
+  width: 100%;
+`
+
+const ShowCard = props => (
+  <Card>
+    <h2>
+      <Link to={`show/${props.id}`}>{props.name}</Link>
+    </h2>
+    <Row>
+      <Col>
+        <dl>
+          <dt>Submission Starts:</dt>
+          <dd>
+            <Moment format='YYYY/MM/DD'>{props.entryStart}</Moment>
+          </dd>
+          <dt>Submission Ends:</dt>
+          <dd>
+            <Moment format='YYYY/MM/DD'>{props.entryEnd}</Moment>
+          </dd>
+        </dl>
+      </Col>
+      <Col>
+        <dl>
+          <dt>Judging Starts:</dt>
+          <dd>
+            <Moment format='YYYY/MM/DD'>{props.judgingStart}</Moment>
+          </dd>
+          <dt>Judging Ends:</dt>
+          <dd>
+            <Moment format='YYYY/MM/DD'>{props.judgingEnd}</Moment>
+          </dd>
+        </dl>
+      </Col>
+    </Row>
+  </Card>
+)
+
+ShowCard.propTypes = {
+  id: PropTypes.string.isRequired,
+  name: PropTypes.string.isRequired,
+  entryStart: PropTypes.string.isRequired,
+  entryEnd: PropTypes.string.isRequired,
+  judgingStart: PropTypes.string.isRequired,
+  judgingEnd: PropTypes.string.isRequired
+}
+
+export default ShowCard

--- a/frontend/src/Judge/components/ShowCard.js
+++ b/frontend/src/Judge/components/ShowCard.js
@@ -16,7 +16,7 @@ const ButtonContainer = styled.div`
   position: absolute;
   right: 0;
   bottom: 0;
-  width: '150px'
+  width: '150px';
 `
 
 const ShowCard = props => (
@@ -37,11 +37,11 @@ const ShowCard = props => (
         <Button
           style={{ cursor: 'pointer' }}
           tag={Link}
-          to={`judge/vote`} // TODO: Figure out where they go to vote
-        // TODO: Conditionally change the text
+          to={`show/${props.id}/vote`}
+          // TODO: Conditionally change the text
         >
           Start
-    </Button>
+        </Button>
       </ButtonContainer>
     </Col>
   </Card>

--- a/frontend/src/Judge/components/Shows.js
+++ b/frontend/src/Judge/components/Shows.js
@@ -1,14 +1,26 @@
 import React from 'react'
+import styled from 'styled-components'
 import PropTypes from 'prop-types'
 
 import ShowCard from '../components/ShowCard'
 
+const NoShowsContainer = styled.div`
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  font-size: large;
+`
+
 const Shows = ({ user, loading }) => (
   <div>
-    {loading ? null :
-    user.shows.length > 0 ? user.shows.map(show => <ShowCard key={show.id} {...show} />) :
-    "You are not currently assinged to a show"
-    }
+    {loading ? null : user.shows.length ? (
+      user.shows.map(show => <ShowCard key={show.id} {...show} />)
+    ) : (
+      <NoShowsContainer>
+        You are not currently assinged to a show
+      </NoShowsContainer>
+    )}
   </div>
 )
 

--- a/frontend/src/Judge/components/Shows.js
+++ b/frontend/src/Judge/components/Shows.js
@@ -1,0 +1,19 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+import ShowCard from '../components/ShowCard'
+
+const Shows = ({ user, loading }) => (
+  <div>
+    {loading ? null :
+    user.shows.length > 0 ? user.shows.map(show => <ShowCard key={show.id} {...show} />) :
+    "You are not currently assinged to a show"
+    }
+  </div>
+)
+
+Shows.propTypes = {
+  user: PropTypes.object,
+  loading: PropTypes.bool.isRequired
+}
+export default Shows

--- a/frontend/src/Judge/containers/Shows.js
+++ b/frontend/src/Judge/containers/Shows.js
@@ -1,0 +1,15 @@
+import { graphql } from 'react-apollo'
+
+import ShowsQuery from '../queries/assignedShows.graphql'
+import Shows from '../components/Shows'
+
+const mapStateToProps = state => ({
+  user: state.shared.auth.user
+})
+
+export default graphql(ShowsQuery, {
+  props: ({ data: { self, loading } }) => ({
+    user: self,
+    loading
+  })
+})(Shows)

--- a/frontend/src/Judge/containers/Shows.js
+++ b/frontend/src/Judge/containers/Shows.js
@@ -3,10 +3,6 @@ import { graphql } from 'react-apollo'
 import ShowsQuery from '../queries/assignedShows.graphql'
 import Shows from '../components/Shows'
 
-const mapStateToProps = state => ({
-  user: state.shared.auth.user
-})
-
 export default graphql(ShowsQuery, {
   props: ({ data: { self, loading } }) => ({
     user: self,

--- a/frontend/src/Judge/pages/Dashboard.js
+++ b/frontend/src/Judge/pages/Dashboard.js
@@ -2,6 +2,8 @@ import React from 'react'
 import { Link } from 'react-router-dom'
 import { Container, Row, Col, Button } from 'reactstrap'
 
+import Shows from '../containers/Shows'
+
 const Dashboard = () => (
   <Container>
     <Row>
@@ -9,6 +11,11 @@ const Dashboard = () => (
         <h1>Dashboard</h1>
       </Col>
       <Col>{/* TODO: Show voting page */}</Col>
+    </Row>
+    <Row>
+      <Col>
+        <Shows />
+      </Col>
     </Row>
   </Container>
 )

--- a/frontend/src/Judge/queries/assignedShows.graphql
+++ b/frontend/src/Judge/queries/assignedShows.graphql
@@ -1,0 +1,13 @@
+query assignedShows {
+  self {
+    shows {
+      id
+      name
+      description
+      entryStart
+      entryEnd
+      judgingStart
+      judgingEnd
+    }
+  }
+}

--- a/frontend/src/Judge/queries/assignedShows.graphql
+++ b/frontend/src/Judge/queries/assignedShows.graphql
@@ -3,10 +3,6 @@ query assignedShows {
     shows {
       id
       name
-      description
-      entryStart
-      entryEnd
-      judgingStart
       judgingEnd
     }
   }


### PR DESCRIPTION
If a judge is assigned  to shows they are listed in the dashboard. Currently all shows are listed because that's the easiest way to retrieve the data.

I also added the "No assigned show" message (solves #173) when there is no show the user has been assigned to.