### PR TITLE
Voting Interface Shell

### DIFF
--- a/frontend/src/Admin/components/CreateJudgeForm.js
+++ b/frontend/src/Admin/components/CreateJudgeForm.js
@@ -28,7 +28,9 @@ class CreateJudgeForm extends Component {
                   className='form-control'
                   required
                 />
-                <span className='input-group-addon'>@rit.edu</span>
+                <div className='input-group-append'>
+                  <span className='input-group-text'>@rit.edu</span>
+                </div>
               </div>
             </FormGroup>
             <Row>

--- a/frontend/src/Judge/Page.js
+++ b/frontend/src/Judge/Page.js
@@ -2,6 +2,8 @@ import React from 'react'
 import { Route, Switch } from 'react-router-dom'
 
 import Dashboard from './pages/Dashboard'
+import Review from './pages/Review'
+import Vote from './pages/Vote'
 
 import Layout from './components/Layout'
 import NotFound from '../shared/components/NotFound'
@@ -10,6 +12,8 @@ const Judge = () => (
   <Layout>
     <Switch>
       <Route exact path='/' component={Dashboard} />
+      <Route exact path='/show/:id' component={Review} />
+      <Route exact path='/show/:id/vote' component={Vote} />
       <Route component={NotFound} />
     </Switch>
   </Layout>

--- a/frontend/src/Judge/actions.js
+++ b/frontend/src/Judge/actions.js
@@ -1,0 +1,39 @@
+import SubmissionQuery from './queries/submission.graphql'
+import SubmissionsQuery from './queries/submissions.graphql'
+
+export const FETCH_SUBMISSION = 'FETCH_SUBMISSION'
+export const FETCH_SUBMISSIONS = 'FETCH_SUBMISSIONS'
+export const NEXT_IN_QUEUE = 'NEXT_IN_QUEUE'
+export const PREVIOUS_IN_QUEUE = 'PREVIOUS_IN_QUEUE'
+
+export const fetchSubmission = submissionId => (dispatch, getState, client) => {
+  return client
+    .query({
+      query: SubmissionQuery,
+      variables: {
+        id: submissionId
+      }
+    })
+    .then(({ data: { submission } }) => dispatch({ type: FETCH_SUBMISSION, payload: submission }))
+    .catch(console.error) // TODO: Handle the error
+}
+
+export const fetchSubmissions = showId => (dispatch, getState, client) => {
+  return client
+    .query({
+      query: SubmissionsQuery,
+      variables: {
+        showId
+      }
+    })
+    .then(({ data: { submissions } }) => dispatch({ type: FETCH_SUBMISSIONS, payload: submissions }))
+    .catch(console.error) // TODO: Handle the error
+}
+
+export const nextInQueue = id => (dispatch, getState, client) => {
+  dispatch({ type: NEXT_IN_QUEUE, payload: { id } })
+}
+
+export const previousInQueue = id => (dispatch, getState, client) => {
+  dispatch({ type: PREVIOUS_IN_QUEUE, payload: { id } })
+}

--- a/frontend/src/Judge/components/OtherMediaSubmission.js
+++ b/frontend/src/Judge/components/OtherMediaSubmission.js
@@ -1,0 +1,9 @@
+import React from 'react'
+
+const OtherMediaSubmission = props => (
+  <div>
+    Other Submission
+  </div>
+)
+
+export default OtherMediaSubmission

--- a/frontend/src/Judge/components/PhotoSubmission.js
+++ b/frontend/src/Judge/components/PhotoSubmission.js
@@ -1,0 +1,9 @@
+import React from 'react'
+
+const PhotoSubmission = props => (
+  <div>
+    Photo Submission
+  </div>
+)
+
+export default PhotoSubmission

--- a/frontend/src/Judge/components/Submission.js
+++ b/frontend/src/Judge/components/Submission.js
@@ -1,0 +1,12 @@
+import React from 'react'
+
+// TODO: This component takes in a 'submission' prop w/ an entry object
+// and switches based off of the entry's type, rendering the correct
+// submission type component (PhotoSubmission, VideoSubmission, OtherMediaSubmission)
+const Submission = props => (
+  <div>
+    Submission
+  </div>
+)
+
+export default Submission

--- a/frontend/src/Judge/components/VideoSubmission.js
+++ b/frontend/src/Judge/components/VideoSubmission.js
@@ -1,0 +1,9 @@
+import React from 'react'
+
+const VideoSubmission = props => (
+  <div>
+    Video Submission
+  </div>
+)
+
+export default VideoSubmission

--- a/frontend/src/Judge/pages/Review.js
+++ b/frontend/src/Judge/pages/Review.js
@@ -1,0 +1,15 @@
+import React from 'react'
+import { Link } from 'react-router-dom'
+import { Container, Row, Col, Button } from 'reactstrap'
+
+const Review = () => (
+  <Container>
+    <Row>
+      <Col>
+        <h1>Review</h1>
+      </Col>
+    </Row>
+  </Container>
+)
+
+export default Review

--- a/frontend/src/Judge/pages/Vote.js
+++ b/frontend/src/Judge/pages/Vote.js
@@ -1,0 +1,157 @@
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
+import { connect } from 'react-redux'
+import { Link } from 'react-router-dom'
+import { Container, Row, Col } from 'reactstrap'
+import styled from 'styled-components'
+import FaChevronLeft from 'react-icons/lib/fa/chevron-left'
+import FaChevronRight from 'react-icons/lib/fa/chevron-right'
+
+import { nextInQueue, previousInQueue } from '../actions'
+import Submission from '../components/Submission'
+
+const Arrow = styled.span`
+  color: black;
+  position: fixed;
+  opacity: 0.25;
+  transition: opacity 0.25s ease-in; /* fade light to dark when hover over */
+  z-index: 10; /* to always be above the submission container */
+
+  &:hover {
+    cursor: pointer;
+    opacity: 1;
+  }
+`
+
+const Previous = Arrow.extend`
+  left: 25px;
+  padding: 225px 25px 200px 0; /* Create a larger click target */
+`
+
+const Next = Arrow.extend`
+  padding: 225px 0 200px 25px; /* Create a larger click target */
+  right: 25px;
+`
+
+const SubmissionContainer = styled.section`
+  height: 100%;
+  text-align: center;
+  width: 100%;
+`
+
+class Vote extends Component {
+  static propTypes = {
+    show: PropTypes.shape({
+      id: PropTypes.string
+    }).isRequired,
+    handlePrevious: PropTypes.func.isRequired,
+    handleNext: PropTypes.func.isRequired,
+    submission: PropTypes.object,
+    previous: PropTypes.shape({
+      id: PropTypes.number
+    }),
+    next: PropTypes.shape({
+      id: PropTypes.number
+    })
+  }
+
+  static defaultProps = {
+    submission: null
+  }
+
+  componentDidMount () {
+    // TODO:
+    // a) If we're visiting this page for the first time (/vote)
+    //   1. fetch all entries for the show we're voting on
+    //   2. create the shuffle order
+    //   3. identify the first unvoted entry; set the 'viewing' state properly
+    //   4. go to the route /show/<show_id>/vote?on=<entry_id> so that the page will re-render populated w/ the entry
+    // b) If we're visiting a specific entry for the first time (/vote?on=<entry_id>) (i.e. refresh)
+    //   1. fetch all entries for the show we're voting on
+    //   2. create the shuffle order
+    //   3. update the 'viewing' state based on the entry in the query param
+    //   4. render the entry in the query param
+    // c) If we're returning to this page (/vote) (i.e. entries and shuffle order exist)
+    //   1. identify the first unvoted entry; set the 'viewing' state properly
+    //   2. go to the route /show/<show_id>/vote?on=<entry_id> so that the page will re-render populated w/ the entry
+    // d) If we're returning to a specific entry on this page (/vote?on=<entry_id>) (i.e. from a) 4. or from review page)
+    //   1. update the 'viewing' state based on the entry in the query param (if they don't already match)
+    //   2. render the entry in the query param
+  }
+
+  render () {
+    const { show, handleNext, handlePrevious, submission, previous, next } = this.props
+
+    return (
+      <Container fluid>
+        <Row>
+          <Col xs='1'>
+            { previous && previous.id
+              ? (
+                <Link to={`/show/${show.id}/vote?on=${previous.id}`}>
+                  <Previous onClick={handlePrevious}>
+                    <FaChevronLeft size='4em' />
+                  </Previous>
+                </Link>
+              ) : null }
+          </Col>
+          <Col xs='10' style={{ minHeight: '500px' }}>
+            <SubmissionContainer>
+              {submission ? <Submission submission={submission} /> : null}
+            </SubmissionContainer>
+          </Col>
+          <Col xs='1'>
+            { next && next.id
+              ? (
+                <Link to={`/show/${show.id}/vote?on=${next.id}`}>
+                  <Next onClick={handleNext}>
+                    <FaChevronRight size='4em' />
+                  </Next>
+                </Link>
+              ) : null }
+          </Col>
+        </Row>
+      </Container>
+    )
+  }
+}
+
+const mapStateToProps = (state, ownProps) => {
+  const showId = ownProps.match.params.id
+  const { order, viewing } = state.judge.queues[showId]
+  const submissions = state.judge.submissions
+
+  const obj = {
+    show: {
+      id: showId
+    },
+    submission: submissions[order[viewing]]
+  }
+
+  // Show the previous button
+  if (viewing > 0) {
+    obj.previous = {
+      id: order[viewing - 1]
+    }
+  }
+
+  // Show the next button
+  if (viewing < order.length) {
+    obj.next = {
+      id: order[viewing + 1]
+    }
+  }
+
+  return obj
+}
+
+const mapDispatchToProps = (dispatch, ownProps) => {
+  const showId = ownProps.match.params.id
+
+  return {
+    handlePrevious: () => dispatch(previousInQueue(showId)),
+    handleNext: () => dispatch(nextInQueue(showId))
+  }
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(Vote)

--- a/frontend/src/Judge/queries/submission.graphql
+++ b/frontend/src/Judge/queries/submission.graphql
@@ -1,0 +1,5 @@
+query Submission($id: ID!) {
+  submission: entry(id: $id) {
+    id
+  }
+}

--- a/frontend/src/Judge/queries/submissions.graphql
+++ b/frontend/src/Judge/queries/submissions.graphql
@@ -1,0 +1,5 @@
+query Submissions($id: ID!) {
+  submissions: entries(showId: $id) {
+    id
+  }
+}

--- a/frontend/src/Judge/reducers.js
+++ b/frontend/src/Judge/reducers.js
@@ -55,7 +55,7 @@ const queue = (state = initialQueueState, action) => {
         ...state,
         // Continue incrementing until we've reached the end of the list.
         // Then continue to return the index of the last element.
-        viewing: viewing < order.length ? viewing + 1 : viewing
+        viewing: viewing + 1 < order.length ? viewing + 1 : viewing
       }
     case actions.PREVIOUS_IN_QUEUE:
       return {

--- a/frontend/src/Judge/reducers.js
+++ b/frontend/src/Judge/reducers.js
@@ -2,6 +2,97 @@ import { combineReducers } from 'redux'
 
 import * as actions from './actions'
 
+// Example State:
+// {
+//   1: {id: '1', title...},
+//   2: {id: '2', title...}
+// }
+const submissions = (state = {}, action) => {
+  switch (action.type) {
+    case actions.FETCH_SUBMISSION:
+      if (!action.payload.id) {
+        return state
+      }
+
+      return {
+        ...state,
+        [action.payload.id]: {
+          ...state[action.payload.id],
+          ...action.payload
+        }
+      }
+    case actions.FETCH_SUBMISSIONS:
+      if (!action.payload.length) {
+        return state
+      }
+
+      const submissions = action.payload.reduce((accum, submission) => {
+        accum[submission.id] = submission
+        return accum
+      }, {})
+      return {
+        ...state,
+        ...submissions
+      }
+    default:
+      return state
+  }
+}
+
+// TODO: Produce 'order' based on shuffling the entry id's that are in this show
+// TODO: Calculate 'viewing' based on the first unvoted entry in 'order'
+const initialQueueState = {
+  order: [], // Array of entry id's
+  viewing: 0 // The index in 'order' we're currently viewing
+}
+
+const queue = (state = initialQueueState, action) => {
+  const { order, viewing } = state
+
+  switch (action.type) {
+    case actions.NEXT_IN_QUEUE:
+      return {
+        ...state,
+        // Continue incrementing until we've reached the end of the list.
+        // Then continue to return the index of the last element.
+        viewing: viewing < order.length ? viewing + 1 : viewing
+      }
+    case actions.PREVIOUS_IN_QUEUE:
+      return {
+        ...state,
+        // Continue decrementing until we've reached the beginning of the list.
+        // Then continue to return the index of the first element (i.e. 0).
+        viewing: viewing > 0 ? viewing - 1 : viewing
+      }
+    default:
+      return state
+  }
+}
+
+// Each show has a queue whose key in the queues state is the show's id
+// Example State:
+// {
+//   1: {order: [1, 2, 3], viewing: 0},
+//   2: {order: [9, 4, 5, 8, 6, 7], viewing: 5}
+// }
+const queues = (state = {}, action) => {
+  // Proxy all queue actions to the particular queue we want to target
+  switch (action.type) {
+    case actions.NEXT_IN_QUEUE:
+    case actions.PREVIOUS_IN_QUEUE:
+      if (!action.payload.id) {
+        return state
+      }
+
+      return {
+        ...state,
+        [action.payload.id]: queue(state[action.payload.id], action)
+      }
+    default:
+      return state
+  }
+}
+
 const ui = (state = {}, action) => {
   switch (action.type) {
     default:
@@ -10,5 +101,7 @@ const ui = (state = {}, action) => {
 }
 
 export default combineReducers({
+  queues,
+  submissions,
   ui
 })

--- a/frontend/src/Student/components/SubmissionFormChooser.js
+++ b/frontend/src/Student/components/SubmissionFormChooser.js
@@ -2,9 +2,9 @@ import React, { Fragment } from 'react'
 import { Link } from 'react-router-dom'
 import { Row, Col } from 'reactstrap'
 import styled from 'styled-components'
-import FaImage from 'babel-loader!react-icons/fa/image'
-import FaVideo from 'babel-loader!react-icons/fa/video-camera'
-import FaBook from 'babel-loader!react-icons/fa/book'
+import FaImage from 'react-icons/lib/fa/image'
+import FaVideo from 'react-icons/lib/fa/video-camera'
+import FaBook from 'react-icons/lib/fa/book'
 
 const Header = styled.h2`
   margin-top: 25px;

--- a/frontend/src/Student/components/SuccessModal.js
+++ b/frontend/src/Student/components/SuccessModal.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import { Modal, ModalBody } from 'reactstrap'
-import FaCheckCircle from 'babel-loader!react-icons/fa/check-circle'
+import FaCheckCircle from 'react-icons/lib/fa/check-circle'
 
 const SuccessModal = props => (
   <Modal


### PR DESCRIPTION
Made a voting page w/ left & right arrows which will go the the "previous" and "next" submissions defined in the queue associated w/ a show. If you're on the first submission, no "previous" arrow is shown. If you're on the last submission, no "next" arrow is shown.

In this current state, the page won't render because it needs additional data fetching which will be done in #169 – see the `TODO` in `frontend/src/Judge/pages/Vote.js` for what will be done.

Additionally, if you refresh the page with any `on=<entry_id>` query param, it won't go to that entry – the expected behavior will be completed in #169.

In order to test this PR, you can set some default state through your `frontend/src/Judge/reducers.js` file:

Change:
```js
const submissions = (state = {}, action) => {
```
to:
```js
const submissions = (state = { 1: {id: '1'}, 2: {id: '2'}, 3: {id: '3'} }, action) => {
```
and
```js
const queues = (state = {}, action) => {
```
to
```js
const queues = (state = { 1: { order: [1, 2, 3], viewing: 0 } }, action) => {
```

And go to `localhost:5000/show/1/vote`

If you also want some visual feedback, in `frontend/src/Judge/components/Submission.js`, you can change `Submission` to `{ props.submission.id }`.

Also fixes some quirks - Bootstrap addon & icon imports.

Wanted to get this in before the end of the sprint since it blocks a lot of other stories & in dev for now, we can work around the data fetching issue.