### PR TITLE
Enforce Submission Limit

### DIFF
--- a/backend/test/resolvers/entry.js
+++ b/backend/test/resolvers/entry.js
@@ -483,6 +483,7 @@ describe('Entry Mutations', function () {
           .then(([user, show]) => {
             const args = {
               input: {
+                entry: standardEntry(user, show),
                 path: 'a/image.jpg'
               }
             }

--- a/frontend/src/Student/components/OtherMediaSubmissionForm.js
+++ b/frontend/src/Student/components/OtherMediaSubmissionForm.js
@@ -8,12 +8,14 @@ import {
   Label,
   Button,
   Row,
-  Col
+  Col,
+  UncontrolledTooltip
 } from 'reactstrap'
 import styled from 'styled-components'
 import Dropzone from 'react-dropzone'
 import { Formik, Field } from 'formik'
 import yup from 'yup'
+import FaQuestionCircle from 'react-icons/lib/fa/question-circle'
 
 import SuccessModal from './SuccessModal'
 
@@ -41,7 +43,13 @@ class OtherSubmissionForm extends Component {
     data: PropTypes.shape({
       show: PropTypes.shape({
         id: PropTypes.string,
-        name: PropTypes.string
+        name: PropTypes.string,
+        entries: PropTypes.arrayOf({
+          id: PropTypes.string,
+          student: PropTypes.shape({
+            username: PropTypes.string
+          })
+        })
       })
     }).isRequired,
     handleImageUpload: PropTypes.func.isRequired,
@@ -152,13 +160,21 @@ class OtherSubmissionForm extends Component {
       name: this.props.data.show.name
     }
 
+    // calculate whether the user is beyond their single submissions
+    const numSingleEntries = this.props.data.show.entries.reduce(
+      // if 'student' is non-null, this is a single submission
+      (n, entry) => entry.student ? n + 1 : n,
+      0
+    )
+    const canSubmitAsSingle = numSingleEntries < this.props.data.show.entryCap
+
     return (
       <Fragment>
         <Formik
           initialValues={{
             academicProgram: '',
             yearLevel: '',
-            submittingAsGroup: 'no',
+            submittingAsGroup: canSubmitAsSingle ? 'no' : 'yes',
             groupParticipants: '',
             title: 'Untitled',
             comment: '',
@@ -261,9 +277,30 @@ class OtherSubmissionForm extends Component {
                           name='submittingAsGroup'
                           value='no'
                           required
+                          disabled={!canSubmitAsSingle}
                           checked={values.submittingAsGroup === 'no'}
                         />
-                        <span className='ml-2'>No</span>
+                        {
+                          canSubmitAsSingle
+                            ? (
+                              <span className='ml-2'>
+                                No
+                              </span>
+                            )
+                            : (
+                              <span className='ml-2 text-muted'>
+                                No&nbsp;
+                                <FaQuestionCircle className='align-middle' id='noSingleHelp' />
+                                <UncontrolledTooltip target='noSingleHelp'>
+                                  <p className='text-left'>
+                                    You have reached your individual submission
+                                    limit for this show. Additional submissions
+                                    must be done as a group.
+                                  </p>
+                                </UncontrolledTooltip>
+                              </span>
+                            )
+                        }
                       </Label>
                     </FormGroup>
                     <FormGroup check>

--- a/frontend/src/Student/components/OtherMediaSubmissionForm.js
+++ b/frontend/src/Student/components/OtherMediaSubmissionForm.js
@@ -163,7 +163,7 @@ class OtherSubmissionForm extends Component {
     // calculate whether the user is beyond their single submissions
     const numSingleEntries = this.props.data.show.entries.reduce(
       // if 'student' is non-null, this is a single submission
-      (n, entry) => entry.student ? n + 1 : n,
+      (n, entry) => (entry.student ? n + 1 : n),
       0
     )
     const canSubmitAsSingle = numSingleEntries < this.props.data.show.entryCap
@@ -280,27 +280,24 @@ class OtherSubmissionForm extends Component {
                           disabled={!canSubmitAsSingle}
                           checked={values.submittingAsGroup === 'no'}
                         />
-                        {
-                          canSubmitAsSingle
-                            ? (
-                              <span className='ml-2'>
-                                No
-                              </span>
-                            )
-                            : (
-                              <span className='ml-2 text-muted'>
-                                No&nbsp;
-                                <FaQuestionCircle className='align-middle' id='noSingleHelp' />
-                                <UncontrolledTooltip target='noSingleHelp'>
-                                  <p className='text-left'>
-                                    You have reached your individual submission
-                                    limit for this show. Additional submissions
-                                    must be done as a group.
-                                  </p>
-                                </UncontrolledTooltip>
-                              </span>
-                            )
-                        }
+                        {canSubmitAsSingle ? (
+                          <span className='ml-2'>No</span>
+                        ) : (
+                          <span className='ml-2 text-muted'>
+                            No&nbsp;
+                            <FaQuestionCircle
+                              className='align-middle'
+                              id='noSingleHelp'
+                            />
+                            <UncontrolledTooltip target='noSingleHelp'>
+                              <p className='text-left'>
+                                You have reached your individual submission
+                                limit for this show. Additional submissions must
+                                be done as a group.
+                              </p>
+                            </UncontrolledTooltip>
+                          </span>
+                        )}
                       </Label>
                     </FormGroup>
                     <FormGroup check>

--- a/frontend/src/Student/components/OtherMediaSubmissionForm.js
+++ b/frontend/src/Student/components/OtherMediaSubmissionForm.js
@@ -8,16 +8,15 @@ import {
   Label,
   Button,
   Row,
-  Col,
-  UncontrolledTooltip
+  Col
 } from 'reactstrap'
 import styled from 'styled-components'
 import Dropzone from 'react-dropzone'
 import { Formik, Field } from 'formik'
 import yup from 'yup'
-import FaQuestionCircle from 'react-icons/lib/fa/question-circle'
 
 import SuccessModal from './SuccessModal'
+import SubmitAsGroupRadio from './SubmitAsGroupRadio'
 
 const Header = styled.h1`
   margin-bottom: 10px;
@@ -267,54 +266,13 @@ class OtherSubmissionForm extends Component {
                     />
                     {this.renderErrors(touched, errors, 'yearLevel')}
                   </FormGroup>
-                  <FormGroup>
-                    <Label>Is this a group submission?</Label>
-                    <FormGroup check>
-                      <Label check>
-                        <Field
-                          type='radio'
-                          id='submittingAsGroup'
-                          name='submittingAsGroup'
-                          value='no'
-                          required
-                          disabled={!canSubmitAsSingle}
-                          checked={values.submittingAsGroup === 'no'}
-                        />
-                        {canSubmitAsSingle ? (
-                          <span className='ml-2'>No</span>
-                        ) : (
-                          <span className='ml-2 text-muted'>
-                            No&nbsp;
-                            <FaQuestionCircle
-                              className='align-middle'
-                              id='noSingleHelp'
-                            />
-                            <UncontrolledTooltip target='noSingleHelp'>
-                              <p className='text-left'>
-                                You have reached your individual submission
-                                limit for this show. Additional submissions must
-                                be done as a group.
-                              </p>
-                            </UncontrolledTooltip>
-                          </span>
-                        )}
-                      </Label>
-                    </FormGroup>
-                    <FormGroup check>
-                      <Label check>
-                        <Field
-                          type='radio'
-                          id='submittingAsGroup'
-                          name='submittingAsGroup'
-                          value='yes'
-                          required
-                          checked={values.submittingAsGroup === 'yes'}
-                        />
-                        <span className='ml-2'>Yes</span>
-                      </Label>
-                    </FormGroup>
-                    {this.renderErrors(touched, errors, 'submittingAsGroup')}
-                  </FormGroup>
+                  <SubmitAsGroupRadio
+                    values={values}
+                    touched={touched}
+                    errors={errors}
+                    canSubmitAsSingle={canSubmitAsSingle}
+                    renderErrors={this.renderErrors}
+                  />
                   {values.submittingAsGroup === 'yes' ? (
                     <FormGroup>
                       <Label>List the names of your other group members.</Label>

--- a/frontend/src/Student/components/PhotoSubmissionForm.js
+++ b/frontend/src/Student/components/PhotoSubmissionForm.js
@@ -8,17 +8,16 @@ import {
   Label,
   Button,
   Row,
-  Col,
-  UncontrolledTooltip
+  Col
 } from 'reactstrap'
 import styled from 'styled-components'
 import Dropzone from 'react-dropzone'
 import { Formik, Field } from 'formik'
 import yup from 'yup'
-import FaQuestionCircle from 'react-icons/lib/fa/question-circle'
 
 import FormikSelectInput from '../../shared/components/FormikSelectInput'
 import SuccessModal from './SuccessModal'
+import SubmitAsGroupRadio from './SubmitAsGroupRadio'
 
 const Header = styled.h1`
   margin-bottom: 10px;
@@ -283,54 +282,13 @@ class PhotoSubmissionForm extends Component {
                     />
                     {this.renderErrors(touched, errors, 'yearLevel')}
                   </FormGroup>
-                  <FormGroup>
-                    <Label>Is this a group submission?</Label>
-                    <FormGroup check>
-                      <Label check>
-                        <Field
-                          type='radio'
-                          id='submittingAsGroup'
-                          name='submittingAsGroup'
-                          value='no'
-                          required
-                          disabled={!canSubmitAsSingle}
-                          checked={values.submittingAsGroup === 'no'}
-                        />
-                        {canSubmitAsSingle ? (
-                          <span className='ml-2'>No</span>
-                        ) : (
-                          <span className='ml-2 text-muted'>
-                            No&nbsp;
-                            <FaQuestionCircle
-                              className='align-middle'
-                              id='noSingleHelp'
-                            />
-                            <UncontrolledTooltip target='noSingleHelp'>
-                              <p className='text-left'>
-                                You have reached your individual submission
-                                limit for this show. Additional submissions must
-                                be done as a group.
-                              </p>
-                            </UncontrolledTooltip>
-                          </span>
-                        )}
-                      </Label>
-                    </FormGroup>
-                    <FormGroup check>
-                      <Label check>
-                        <Field
-                          type='radio'
-                          id='submittingAsGroup'
-                          name='submittingAsGroup'
-                          value='yes'
-                          required
-                          checked={values.submittingAsGroup === 'yes'}
-                        />
-                        <span className='ml-2'>Yes</span>
-                      </Label>
-                    </FormGroup>
-                    {this.renderErrors(touched, errors, 'submittingAsGroup')}
-                  </FormGroup>
+                  <SubmitAsGroupRadio
+                    values={values}
+                    touched={touched}
+                    errors={errors}
+                    canSubmitAsSingle={canSubmitAsSingle}
+                    renderErrors={this.renderErrors}
+                  />
                   {values.submittingAsGroup === 'yes' ? (
                     <FormGroup>
                       <Label>List the names of your other group members.</Label>

--- a/frontend/src/Student/components/PhotoSubmissionForm.js
+++ b/frontend/src/Student/components/PhotoSubmissionForm.js
@@ -8,12 +8,14 @@ import {
   Label,
   Button,
   Row,
-  Col
+  Col,
+  UncontrolledTooltip
 } from 'reactstrap'
 import styled from 'styled-components'
 import Dropzone from 'react-dropzone'
 import { Formik, Field } from 'formik'
 import yup from 'yup'
+import FaQuestionCircle from 'react-icons/lib/fa/question-circle'
 
 import FormikSelectInput from '../../shared/components/FormikSelectInput'
 import SuccessModal from './SuccessModal'
@@ -42,7 +44,13 @@ class PhotoSubmissionForm extends Component {
     data: PropTypes.shape({
       show: PropTypes.shape({
         id: PropTypes.string,
-        name: PropTypes.string
+        name: PropTypes.string,
+        entries: PropTypes.arrayOf({
+          id: PropTypes.string,
+          student: PropTypes.shape({
+            username: PropTypes.string
+          })
+        })
       })
     }).isRequired,
     handleUpload: PropTypes.func.isRequired,
@@ -142,13 +150,21 @@ class PhotoSubmissionForm extends Component {
       name: this.props.data.show.name
     }
 
+    // calculate whether the user is beyond their single submissions
+    const numSingleEntries = this.props.data.show.entries.reduce(
+      // if 'student' is non-null, this is a single submission
+      (n, entry) => entry.student ? n + 1 : n,
+      0
+    )
+    const canSubmitAsSingle = numSingleEntries < this.props.data.show.entryCap
+
     return (
       <Fragment>
         <Formik
           initialValues={{
             academicProgram: '',
             yearLevel: '',
-            submittingAsGroup: 'no',
+            submittingAsGroup: canSubmitAsSingle ? 'no' : 'yes',
             groupParticipants: '',
             title: 'Untitled',
             comment: '',
@@ -277,9 +293,30 @@ class PhotoSubmissionForm extends Component {
                           name='submittingAsGroup'
                           value='no'
                           required
+                          disabled={!canSubmitAsSingle}
                           checked={values.submittingAsGroup === 'no'}
                         />
-                        <span className='ml-2'>No</span>
+                        {
+                          canSubmitAsSingle
+                            ? (
+                              <span className='ml-2'>
+                                No
+                              </span>
+                            )
+                            : (
+                              <span className='ml-2 text-muted'>
+                                No&nbsp;
+                                <FaQuestionCircle className='align-middle' id='noSingleHelp' />
+                                <UncontrolledTooltip target='noSingleHelp'>
+                                  <p className='text-left'>
+                                    You have reached your individual submission
+                                    limit for this show. Additional submissions
+                                    must be done as a group.
+                                  </p>
+                                </UncontrolledTooltip>
+                              </span>
+                            )
+                        }
                       </Label>
                     </FormGroup>
                     <FormGroup check>

--- a/frontend/src/Student/components/PhotoSubmissionForm.js
+++ b/frontend/src/Student/components/PhotoSubmissionForm.js
@@ -153,7 +153,7 @@ class PhotoSubmissionForm extends Component {
     // calculate whether the user is beyond their single submissions
     const numSingleEntries = this.props.data.show.entries.reduce(
       // if 'student' is non-null, this is a single submission
-      (n, entry) => entry.student ? n + 1 : n,
+      (n, entry) => (entry.student ? n + 1 : n),
       0
     )
     const canSubmitAsSingle = numSingleEntries < this.props.data.show.entryCap
@@ -296,27 +296,24 @@ class PhotoSubmissionForm extends Component {
                           disabled={!canSubmitAsSingle}
                           checked={values.submittingAsGroup === 'no'}
                         />
-                        {
-                          canSubmitAsSingle
-                            ? (
-                              <span className='ml-2'>
-                                No
-                              </span>
-                            )
-                            : (
-                              <span className='ml-2 text-muted'>
-                                No&nbsp;
-                                <FaQuestionCircle className='align-middle' id='noSingleHelp' />
-                                <UncontrolledTooltip target='noSingleHelp'>
-                                  <p className='text-left'>
-                                    You have reached your individual submission
-                                    limit for this show. Additional submissions
-                                    must be done as a group.
-                                  </p>
-                                </UncontrolledTooltip>
-                              </span>
-                            )
-                        }
+                        {canSubmitAsSingle ? (
+                          <span className='ml-2'>No</span>
+                        ) : (
+                          <span className='ml-2 text-muted'>
+                            No&nbsp;
+                            <FaQuestionCircle
+                              className='align-middle'
+                              id='noSingleHelp'
+                            />
+                            <UncontrolledTooltip target='noSingleHelp'>
+                              <p className='text-left'>
+                                You have reached your individual submission
+                                limit for this show. Additional submissions must
+                                be done as a group.
+                              </p>
+                            </UncontrolledTooltip>
+                          </span>
+                        )}
                       </Label>
                     </FormGroup>
                     <FormGroup check>

--- a/frontend/src/Student/components/SubmitAsGroupRadio.js
+++ b/frontend/src/Student/components/SubmitAsGroupRadio.js
@@ -1,0 +1,59 @@
+import React from 'react'
+import { Label, FormGroup, UncontrolledTooltip } from 'reactstrap'
+import { Field } from 'formik'
+import FaQuestionCircle from 'react-icons/lib/fa/question-circle'
+
+export default function SubmitAsGroupRadio ({
+  values,
+  touched,
+  errors,
+  canSubmitAsSingle,
+  renderErrors
+}) {
+  return (
+    <FormGroup>
+      <Label>Is this a group submission?</Label>
+      <FormGroup check>
+        <Label check>
+          <Field
+            type='radio'
+            id='submittingAsGroup'
+            name='submittingAsGroup'
+            value='no'
+            required
+            disabled={!canSubmitAsSingle}
+            checked={values.submittingAsGroup === 'no'}
+          />
+          {canSubmitAsSingle ? (
+            <span className='ml-2'>No</span>
+          ) : (
+            <span className='ml-2 text-muted'>
+              No&nbsp;
+              <FaQuestionCircle className='align-middle' id='noSingleHelp' />
+              <UncontrolledTooltip target='noSingleHelp'>
+                <p className='text-left'>
+                  You have reached your individual submission limit for this
+                  show. Additional submissions must be done as a group.
+                </p>
+              </UncontrolledTooltip>
+            </span>
+          )}
+        </Label>
+      </FormGroup>
+      <FormGroup check>
+        <Label check>
+          <Field
+            type='radio'
+            id='submittingAsGroup'
+            name='submittingAsGroup'
+            value='yes'
+            required
+            checked={values.submittingAsGroup === 'yes'}
+          />
+          <span className='ml-2'>Yes</span>
+        </Label>
+      </FormGroup>
+      {renderErrors(touched, errors, 'submittingAsGroup')}
+    </FormGroup>
+  )
+}

--- a/frontend/src/Student/components/VideoSubmissionForm.js
+++ b/frontend/src/Student/components/VideoSubmissionForm.js
@@ -86,7 +86,7 @@ class VideoSubmissionForm extends Component {
     // calculate whether the user is beyond their single submissions
     const numSingleEntries = this.props.data.show.entries.reduce(
       // if 'student' is non-null, this is a single submission
-      (n, entry) => entry.student ? n + 1 : n,
+      (n, entry) => (entry.student ? n + 1 : n),
       0
     )
     const canSubmitAsSingle = numSingleEntries < this.props.data.show.entryCap
@@ -206,27 +206,24 @@ class VideoSubmissionForm extends Component {
                           disabled={!canSubmitAsSingle}
                           checked={values.submittingAsGroup === 'no'}
                         />
-                        {
-                          canSubmitAsSingle
-                            ? (
-                              <span className='ml-2'>
-                                No
-                              </span>
-                            )
-                            : (
-                              <span className='ml-2 text-muted'>
-                                No&nbsp;
-                                <FaQuestionCircle className='align-middle' id='noSingleHelp' />
-                                <UncontrolledTooltip target='noSingleHelp'>
-                                  <p className='text-left'>
-                                    You have reached your individual submission
-                                    limit for this show. Additional submissions
-                                    must be done as a group.
-                                  </p>
-                                </UncontrolledTooltip>
-                              </span>
-                            )
-                        }
+                        {canSubmitAsSingle ? (
+                          <span className='ml-2'>No</span>
+                        ) : (
+                          <span className='ml-2 text-muted'>
+                            No&nbsp;
+                            <FaQuestionCircle
+                              className='align-middle'
+                              id='noSingleHelp'
+                            />
+                            <UncontrolledTooltip target='noSingleHelp'>
+                              <p className='text-left'>
+                                You have reached your individual submission
+                                limit for this show. Additional submissions must
+                                be done as a group.
+                              </p>
+                            </UncontrolledTooltip>
+                          </span>
+                        )}
                       </Label>
                     </FormGroup>
                     <FormGroup check>

--- a/frontend/src/Student/components/VideoSubmissionForm.js
+++ b/frontend/src/Student/components/VideoSubmissionForm.js
@@ -8,15 +8,14 @@ import {
   Label,
   Button,
   Row,
-  Col,
-  UncontrolledTooltip
+  Col
 } from 'reactstrap'
 import styled from 'styled-components'
 import { Formik, Field } from 'formik'
 import yup from 'yup'
-import FaQuestionCircle from 'react-icons/lib/fa/question-circle'
 
 import SuccessModal from './SuccessModal'
+import SubmitAsGroupRadio from './SubmitAsGroupRadio'
 
 const Header = styled.h1`
   margin-bottom: 10px;
@@ -193,54 +192,13 @@ class VideoSubmissionForm extends Component {
                     />
                     {this.renderErrors(touched, errors, 'yearLevel')}
                   </FormGroup>
-                  <FormGroup>
-                    <Label>Is this a group submission?</Label>
-                    <FormGroup check>
-                      <Label check>
-                        <Field
-                          type='radio'
-                          id='submittingAsGroup'
-                          name='submittingAsGroup'
-                          value='no'
-                          required
-                          disabled={!canSubmitAsSingle}
-                          checked={values.submittingAsGroup === 'no'}
-                        />
-                        {canSubmitAsSingle ? (
-                          <span className='ml-2'>No</span>
-                        ) : (
-                          <span className='ml-2 text-muted'>
-                            No&nbsp;
-                            <FaQuestionCircle
-                              className='align-middle'
-                              id='noSingleHelp'
-                            />
-                            <UncontrolledTooltip target='noSingleHelp'>
-                              <p className='text-left'>
-                                You have reached your individual submission
-                                limit for this show. Additional submissions must
-                                be done as a group.
-                              </p>
-                            </UncontrolledTooltip>
-                          </span>
-                        )}
-                      </Label>
-                    </FormGroup>
-                    <FormGroup check>
-                      <Label check>
-                        <Field
-                          type='radio'
-                          id='submittingAsGroup'
-                          name='submittingAsGroup'
-                          value='yes'
-                          required
-                          checked={values.submittingAsGroup === 'yes'}
-                        />
-                        <span className='ml-2'>Yes</span>
-                      </Label>
-                    </FormGroup>
-                    {this.renderErrors(touched, errors, 'submittingAsGroup')}
-                  </FormGroup>
+                  <SubmitAsGroupRadio
+                    values={values}
+                    touched={touched}
+                    errors={errors}
+                    canSubmitAsSingle={canSubmitAsSingle}
+                    renderErrors={this.renderErrors}
+                  />
                   {values.submittingAsGroup === 'yes' ? (
                     <FormGroup>
                       <Label>List the names of your other group members.</Label>

--- a/frontend/src/Student/components/VideoSubmissionForm.js
+++ b/frontend/src/Student/components/VideoSubmissionForm.js
@@ -8,11 +8,13 @@ import {
   Label,
   Button,
   Row,
-  Col
+  Col,
+  UncontrolledTooltip
 } from 'reactstrap'
 import styled from 'styled-components'
 import { Formik, Field } from 'formik'
 import yup from 'yup'
+import FaQuestionCircle from 'react-icons/lib/fa/question-circle'
 
 import SuccessModal from './SuccessModal'
 
@@ -36,7 +38,13 @@ class VideoSubmissionForm extends Component {
     data: PropTypes.shape({
       show: PropTypes.shape({
         id: PropTypes.string,
-        name: PropTypes.string
+        name: PropTypes.string,
+        entries: PropTypes.arrayOf({
+          id: PropTypes.string,
+          student: PropTypes.shape({
+            username: PropTypes.string
+          })
+        })
       })
     }).isRequired,
     create: PropTypes.func.isRequired,
@@ -75,13 +83,21 @@ class VideoSubmissionForm extends Component {
       name: this.props.data.show.name
     }
 
+    // calculate whether the user is beyond their single submissions
+    const numSingleEntries = this.props.data.show.entries.reduce(
+      // if 'student' is non-null, this is a single submission
+      (n, entry) => entry.student ? n + 1 : n,
+      0
+    )
+    const canSubmitAsSingle = numSingleEntries < this.props.data.show.entryCap
+
     return (
       <Fragment>
         <Formik
           initialValues={{
             academicProgram: '',
             yearLevel: '',
-            submittingAsGroup: 'no',
+            submittingAsGroup: canSubmitAsSingle ? 'no' : 'yes',
             groupParticipants: '',
             title: 'Untitled',
             comment: '',
@@ -187,9 +203,30 @@ class VideoSubmissionForm extends Component {
                           name='submittingAsGroup'
                           value='no'
                           required
+                          disabled={!canSubmitAsSingle}
                           checked={values.submittingAsGroup === 'no'}
                         />
-                        <span className='ml-2'>No</span>
+                        {
+                          canSubmitAsSingle
+                            ? (
+                              <span className='ml-2'>
+                                No
+                              </span>
+                            )
+                            : (
+                              <span className='ml-2 text-muted'>
+                                No&nbsp;
+                                <FaQuestionCircle className='align-middle' id='noSingleHelp' />
+                                <UncontrolledTooltip target='noSingleHelp'>
+                                  <p className='text-left'>
+                                    You have reached your individual submission
+                                    limit for this show. Additional submissions
+                                    must be done as a group.
+                                  </p>
+                                </UncontrolledTooltip>
+                              </span>
+                            )
+                        }
                       </Label>
                     </FormGroup>
                     <FormGroup check>

--- a/frontend/src/Student/containers/OtherMediaSubmissionForm.js
+++ b/frontend/src/Student/containers/OtherMediaSubmissionForm.js
@@ -6,7 +6,7 @@ import { uploadImage, uploadPDF, clearPreview } from '../actions'
 
 import OtherMediaSubmissionForm from '../components/OtherMediaSubmissionForm'
 import CreateOtherMediaEntry from '../mutations/createOtherMediaEntry.graphql'
-import ShowName from '../queries/showName.graphql'
+import ShowForSubmission from '../queries/showForSubmission.graphql'
 
 const mapStateToProps = state => ({
   previewFile: state.student.ui.submission.previewFile || {},
@@ -33,7 +33,7 @@ const withMutations = compose(
         })
     })
   }),
-  graphql(ShowName, {
+  graphql(ShowForSubmission, {
     options: ownProps => ({
       variables: {
         id: ownProps.id

--- a/frontend/src/Student/containers/PhotoSubmissionForm.js
+++ b/frontend/src/Student/containers/PhotoSubmissionForm.js
@@ -6,7 +6,7 @@ import { uploadImage, clearPreview } from '../actions'
 
 import PhotoSubmissionForm from '../components/PhotoSubmissionForm'
 import CreatePhotoEntry from '../mutations/createPhotoEntry.graphql'
-import ShowName from '../queries/showName.graphql'
+import ShowForSubmission from '../queries/showForSubmission.graphql'
 
 const mapStateToProps = state => ({
   previewImage: state.student.ui.submission.previewFile || {},
@@ -33,7 +33,7 @@ const withMutations = compose(
         })
     })
   }),
-  graphql(ShowName, {
+  graphql(ShowForSubmission, {
     options: ownProps => ({
       variables: {
         id: ownProps.id

--- a/frontend/src/Student/containers/VideoSubmissionForm.js
+++ b/frontend/src/Student/containers/VideoSubmissionForm.js
@@ -4,7 +4,7 @@ import { connect } from 'react-redux'
 
 import VideoSubmissionForm from '../components/VideoSubmissionForm'
 import CreateVideoEntry from '../mutations/createVideoEntry.graphql'
-import ShowName from '../queries/showName.graphql'
+import ShowForSubmission from '../queries/showForSubmission.graphql'
 
 const mapStateToProps = state => ({
   user: state.shared.auth.user
@@ -27,7 +27,7 @@ const withMutations = compose(
         })
     })
   }),
-  graphql(ShowName, {
+  graphql(ShowForSubmission, {
     options: ownProps => ({
       variables: {
         id: ownProps.id

--- a/frontend/src/Student/queries/showForSubmission.graphql
+++ b/frontend/src/Student/queries/showForSubmission.graphql
@@ -1,0 +1,14 @@
+query Show($id: ID!) {
+  show(id: $id) {
+    id
+    name
+    entryCap
+    entries {
+      id
+      # we need the student to tell if this is a group submission or not
+      student {
+        username
+      }
+    }
+  }
+}

--- a/frontend/src/Student/queries/showName.graphql
+++ b/frontend/src/Student/queries/showName.graphql
@@ -1,6 +1,0 @@
-query Show($id: ID!) {
-  show(id: $id) {
-    id
-    name
-  }
-}


### PR DESCRIPTION
Adds both frontend and backend enforcement for the submission limit cap.

On the frontend, the option to submit alone is disabled and a help-tooltip appears to explain why. See photos below.

Disabled 'No' option:

![group_submit](https://user-images.githubusercontent.com/884115/36922599-665b3d9a-1e36-11e8-98bc-06b4b63b203c.PNG)

And the tooltip:

![group_submit_1](https://user-images.githubusercontent.com/884115/36922598-662ad6fa-1e36-11e8-8c41-b0a073c41103.PNG)


On the backend a UserError is thrown with text 'Individual submission limit reached'