### PR TITLE
Adding left and right arrow key input for vote navigation

### DIFF
--- a/frontend/src/Judge/actions.js
+++ b/frontend/src/Judge/actions.js
@@ -14,7 +14,9 @@ export const fetchSubmission = submissionId => (dispatch, getState, client) => {
         id: submissionId
       }
     })
-    .then(({ data: { submission } }) => dispatch({ type: FETCH_SUBMISSION, payload: submission }))
+    .then(({ data: { submission } }) =>
+      dispatch({ type: FETCH_SUBMISSION, payload: submission })
+    )
     .catch(console.error) // TODO: Handle the error
 }
 
@@ -26,7 +28,9 @@ export const fetchSubmissions = showId => (dispatch, getState, client) => {
         showId
       }
     })
-    .then(({ data: { submissions } }) => dispatch({ type: FETCH_SUBMISSIONS, payload: submissions }))
+    .then(({ data: { submissions } }) =>
+      dispatch({ type: FETCH_SUBMISSIONS, payload: submissions })
+    )
     .catch(console.error) // TODO: Handle the error
 }
 

--- a/frontend/src/Judge/components/OtherMediaSubmission.js
+++ b/frontend/src/Judge/components/OtherMediaSubmission.js
@@ -1,9 +1,5 @@
 import React from 'react'
 
-const OtherMediaSubmission = props => (
-  <div>
-    Other Submission
-  </div>
-)
+const OtherMediaSubmission = props => <div>Other Submission</div>
 
 export default OtherMediaSubmission

--- a/frontend/src/Judge/components/PhotoSubmission.js
+++ b/frontend/src/Judge/components/PhotoSubmission.js
@@ -1,9 +1,5 @@
 import React from 'react'
 
-const PhotoSubmission = props => (
-  <div>
-    Photo Submission
-  </div>
-)
+const PhotoSubmission = props => <div>Photo Submission</div>
 
 export default PhotoSubmission

--- a/frontend/src/Judge/components/ShowCard.js
+++ b/frontend/src/Judge/components/ShowCard.js
@@ -43,9 +43,7 @@ const DuringJudging = ({ ownVotes, entries, judgingEnd, id }) => (
         >
           {ownVotes.length === 0
             ? 'Start'
-            : ownVotes.length === entries.length
-              ? 'Review'
-              : 'Resume'}
+            : ownVotes.length === entries.length ? 'Review' : 'Resume'}
         </Button>
       </ButtonContainer>
     </Col>

--- a/frontend/src/Judge/components/Submission.js
+++ b/frontend/src/Judge/components/Submission.js
@@ -3,10 +3,6 @@ import React from 'react'
 // TODO: This component takes in a 'submission' prop w/ an entry object
 // and switches based off of the entry's type, rendering the correct
 // submission type component (PhotoSubmission, VideoSubmission, OtherMediaSubmission)
-const Submission = props => (
-  <div>
-    Submission
-  </div>
-)
+const Submission = props => <div>Submission</div>
 
 export default Submission

--- a/frontend/src/Judge/components/VideoSubmission.js
+++ b/frontend/src/Judge/components/VideoSubmission.js
@@ -1,9 +1,5 @@
 import React from 'react'
 
-const VideoSubmission = props => (
-  <div>
-    Video Submission
-  </div>
-)
+const VideoSubmission = props => <div>Video Submission</div>
 
 export default VideoSubmission

--- a/frontend/src/Judge/pages/Vote.js
+++ b/frontend/src/Judge/pages/Vote.js
@@ -117,11 +117,7 @@ class Vote extends Component {
     } = this.props
 
     return (
-      <Container
-        fluid
-        // tabIndex='0'
-        // onKeyDown={(e) => this.handleKeyInput(e, handleNext, handlePrevious, show, previous, next)}
-      >
+      <Container fluid>
         <Row>
           <Col xs='1'>
             {previous && previous.id ? (

--- a/frontend/src/Judge/pages/Vote.js
+++ b/frontend/src/Judge/pages/Vote.js
@@ -40,9 +40,16 @@ const SubmissionContainer = styled.section`
 `
 
 class Vote extends Component {
-  handleKeyInput = (e) => {
-    const { show, handleNext, handlePrevious, submission, previous, next } = this.props
-    if (e.key === "ArrowRight"){
+  handleKeyInput = e => {
+    const {
+      show,
+      handleNext,
+      handlePrevious,
+      submission,
+      previous,
+      next
+    } = this.props
+    if (e.key === 'ArrowRight') {
       if (next && next.id) {
         handleNext()
         this.props.history.push(`/show/${show.id}/vote?on=${next.id}`)
@@ -54,7 +61,7 @@ class Vote extends Component {
       }
     }
   }
-  
+
   static propTypes = {
     show: PropTypes.shape({
       id: PropTypes.string
@@ -74,12 +81,12 @@ class Vote extends Component {
     submission: null
   }
 
-  componentWillUnmount() {
-    document.removeEventListener("keydown", this.handleKeyInput)
+  componentWillUnmount () {
+    document.removeEventListener('keydown', this.handleKeyInput)
   }
-  
+
   componentDidMount () {
-    document.addEventListener("keydown", this.handleKeyInput)
+    document.addEventListener('keydown', this.handleKeyInput)
     // TODO:
     // a) If we're visiting this page for the first time (/vote)
     //   1. fetch all entries for the show we're voting on
@@ -100,23 +107,30 @@ class Vote extends Component {
   }
 
   render () {
-    const { show, handleNext, handlePrevious, submission, previous, next } = this.props
+    const {
+      show,
+      handleNext,
+      handlePrevious,
+      submission,
+      previous,
+      next
+    } = this.props
 
     return (
-      <Container fluid
+      <Container
+        fluid
         // tabIndex='0'
         // onKeyDown={(e) => this.handleKeyInput(e, handleNext, handlePrevious, show, previous, next)}
       >
-        <Row >
+        <Row>
           <Col xs='1'>
-            { previous && previous.id
-              ? (
-                <Link to={`/show/${show.id}/vote?on=${previous.id}`}>
-                  <Previous onClick={handlePrevious}>
-                    <FaChevronLeft size='4em' />
-                  </Previous>
-                </Link>
-              ) : null }
+            {previous && previous.id ? (
+              <Link to={`/show/${show.id}/vote?on=${previous.id}`}>
+                <Previous onClick={handlePrevious}>
+                  <FaChevronLeft size='4em' />
+                </Previous>
+              </Link>
+            ) : null}
           </Col>
           <Col xs='10' style={{ minHeight: '500px' }}>
             <SubmissionContainer>
@@ -124,14 +138,13 @@ class Vote extends Component {
             </SubmissionContainer>
           </Col>
           <Col xs='1'>
-            { next && next.id
-              ? (
-                <Link to={`/show/${show.id}/vote?on=${next.id}`}>
-                  <Next onClick={handleNext}>
-                    <FaChevronRight size='4em' />
-                  </Next>
-                </Link>
-              ) : null }
+            {next && next.id ? (
+              <Link to={`/show/${show.id}/vote?on=${next.id}`}>
+                <Next onClick={handleNext}>
+                  <FaChevronRight size='4em' />
+                </Next>
+              </Link>
+            ) : null}
           </Col>
         </Row>
       </Container>

--- a/frontend/src/Judge/pages/Vote.js
+++ b/frontend/src/Judge/pages/Vote.js
@@ -40,6 +40,21 @@ const SubmissionContainer = styled.section`
 `
 
 class Vote extends Component {
+  handleKeyInput = (e) => {
+    const { show, handleNext, handlePrevious, submission, previous, next } = this.props
+    if (e.key === "ArrowRight"){
+      if (next && next.id) {
+        handleNext()
+        this.props.history.push(`/show/${show.id}/vote?on=${next.id}`)
+      }
+    } else if (e.key === 'ArrowLeft') {
+      if (previous && previous.id) {
+        handlePrevious()
+        this.props.history.push(`/show/${show.id}/vote?on=${previous.id}`)
+      }
+    }
+  }
+  
   static propTypes = {
     show: PropTypes.shape({
       id: PropTypes.string
@@ -59,7 +74,12 @@ class Vote extends Component {
     submission: null
   }
 
+  componentWillUnmount() {
+    document.removeEventListener("keydown", this.handleKeyInput)
+  }
+  
   componentDidMount () {
+    document.addEventListener("keydown", this.handleKeyInput)
     // TODO:
     // a) If we're visiting this page for the first time (/vote)
     //   1. fetch all entries for the show we're voting on
@@ -83,8 +103,11 @@ class Vote extends Component {
     const { show, handleNext, handlePrevious, submission, previous, next } = this.props
 
     return (
-      <Container fluid>
-        <Row>
+      <Container fluid
+        // tabIndex='0'
+        // onKeyDown={(e) => this.handleKeyInput(e, handleNext, handlePrevious, show, previous, next)}
+      >
+        <Row >
           <Col xs='1'>
             { previous && previous.id
               ? (

--- a/frontend/src/Judge/reducers.js
+++ b/frontend/src/Judge/reducers.js
@@ -7,10 +7,7 @@ import * as actions from './actions'
 //   1: {id: '1', title...},
 //   2: {id: '2', title...}
 // }
-const submissions = (
-  state = { 1: { id: '1' }, 2: { id: '2' }, 3: { id: '3' } },
-  action
-) => {
+const submissions = (state = {}, action) => {
   switch (action.type) {
     case actions.FETCH_SUBMISSION:
       if (!action.payload.id) {
@@ -78,7 +75,7 @@ const queue = (state = initialQueueState, action) => {
 //   1: {order: [1, 2, 3], viewing: 0},
 //   2: {order: [9, 4, 5, 8, 6, 7], viewing: 5}
 // }
-const queues = (state = { 2: { order: [1, 2, 3], viewing: 0 } }, action) => {
+const queues = (state = {}, action) => {
   // Proxy all queue actions to the particular queue we want to target
   switch (action.type) {
     case actions.NEXT_IN_QUEUE:

--- a/frontend/src/Judge/reducers.js
+++ b/frontend/src/Judge/reducers.js
@@ -7,7 +7,10 @@ import * as actions from './actions'
 //   1: {id: '1', title...},
 //   2: {id: '2', title...}
 // }
-const submissions = (state = {}, action) => {
+const submissions = (
+  state = { 1: { id: '1' }, 2: { id: '2' }, 3: { id: '3' } },
+  action
+) => {
   switch (action.type) {
     case actions.FETCH_SUBMISSION:
       if (!action.payload.id) {
@@ -75,7 +78,7 @@ const queue = (state = initialQueueState, action) => {
 //   1: {order: [1, 2, 3], viewing: 0},
 //   2: {order: [9, 4, 5, 8, 6, 7], viewing: 5}
 // }
-const queues = (state = {}, action) => {
+const queues = (state = { 2: { order: [1, 2, 3], viewing: 0 } }, action) => {
   // Proxy all queue actions to the particular queue we want to target
   switch (action.type) {
     case actions.NEXT_IN_QUEUE:

--- a/frontend/src/Student/components/ShowCard.js
+++ b/frontend/src/Student/components/ShowCard.js
@@ -161,7 +161,6 @@ const ShowCard = props => (
           <div>No Longer Accepting Submissions</div>
         ) : (
           <div>
-            {' '}
             Accepting Submissions Until:{' '}
             <Moment format='MMMM Do YYYY'>{props.show.entryEnd}</Moment>
           </div>

--- a/frontend/src/Student/components/ShowCard.js
+++ b/frontend/src/Student/components/ShowCard.js
@@ -34,7 +34,7 @@ const EntryNoThumbContainer = styled.div`
   padding: 15px;
 `
 const EntryContainer = styled.div`
-  width: inherit
+  width: inherit;
 `
 
 const JudgingPhase = styled.div`
@@ -44,7 +44,7 @@ const JudgingPhase = styled.div`
   border-radius: 0.25rem;
   color: #856404;
   position: relative;
-  width: inherit
+  width: inherit;
 `
 const Accepted = styled.div`
   background-color: #d4edda;
@@ -53,7 +53,7 @@ const Accepted = styled.div`
   border-radius: 0.25rem;
   color: #155724;
   position: relative;
-  width: inherit
+  width: inherit;
 `
 
 const NotAccepted = styled.div`
@@ -63,7 +63,7 @@ const NotAccepted = styled.div`
   border-radius: 0.25rem;
   color: #1b1e21;
   position: relative;
-  width: inherit
+  width: inherit;
 `
 
 const EntryThumb = ({ entry }) => {
@@ -130,7 +130,7 @@ const SubmittedEntries = ({ show }) =>
     >
       <EntryContainer>
         <EntryThumb entry={entry} />
-        {/* If after entry end and before judging end, display "judging phase" 
+        {/* If after entry end and before judging end, display "judging phase"
           , else display accepted or denied */
           moment().isBetween(show.entryEnd, show.judgingEnd) ? (
             <JudgingPhase>Judging In Progress</JudgingPhase>
@@ -138,8 +138,8 @@ const SubmittedEntries = ({ show }) =>
             entry.invited ? (
               <Accepted>Invited</Accepted>
             ) : (
-                <NotAccepted>Not Invited</NotAccepted>
-              )
+              <NotAccepted>Not Invited</NotAccepted>
+            )
           ) : null}
       </EntryContainer>
     </Col>
@@ -160,15 +160,20 @@ const ShowCard = props => (
         {moment().isAfter(moment(props.show.entryEnd)) ? (
           <div>No Longer Accepting Submissions</div>
         ) : (
-            <div> Accepting Submissions Until:{' '}
-              <Moment format='MMMM Do YYYY'>{props.show.entryEnd}</Moment></div>
-          )}
+          <div>
+            {' '}
+            Accepting Submissions Until:{' '}
+            <Moment format='MMMM Do YYYY'>{props.show.entryEnd}</Moment>
+          </div>
+        )}
       </Col>
     </Row>
     <hr />
     <Row style={{ minHeight: '250px' }} className='align-items-center'>
       <Fragment>
-        {moment().isBefore(props.show.entryEnd) ? <NewSubmission {...props} /> : null}
+        {moment().isBefore(props.show.entryEnd) ? (
+          <NewSubmission {...props} />
+        ) : null}
         <SubmittedEntries {...props} />
       </Fragment>
     </Row>


### PR DESCRIPTION
Left and right arrow keys can be used to navigate between pages, other key input is ignored. 

Fronend linting isn't running on push. I'm going to try to fix that. Just look at `frontend/src/Judge/pages/Vote.js` for the changes.

In order to test this PR, you can set some default state through your `frontend/src/Judge/reducers.js` file (just like in Bill's last PR):
Change:
```js
const submissions = (state = {}, action) => {
```
to:
```js
const submissions = (state = { 1: {id: '1'}, 2: {id: '2'}, 3: {id: '3'} }, action) => {
```
and
```js
const queues = (state = {}, action) => {
```
to
```js
const queues = (state = { 1: { order: [1, 2, 3], viewing: 0 } }, action) => {
```