### PR TITLE
Add show-specific page for Admins, with tabs

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -57,6 +57,7 @@
     "react-moment": "^0.7.0",
     "react-redux": "^5.0.6",
     "react-router-dom": "^4.2.2",
+    "react-router-tabs": "^1.1.1",
     "react-select": "^1.2.1",
     "react-table": "^6.7.4",
     "reactstrap": "^5.0.0-alpha.3",

--- a/frontend/src/Admin/Page.js
+++ b/frontend/src/Admin/Page.js
@@ -15,8 +15,8 @@ const Admin = () => (
     <Switch>
       <Route exact path='/' component={Dashboard} />
       <Route exact path='/show/new' component={CreateShow} />
-      <Route exact path='/show/:id' component={ViewShow} />
-      <Route exact path='/show/:id/judges' component={AssignJudges} />
+      <Route exact path='/show/:id/judges/assign' component={AssignJudges} />
+      <Route path='/show/:id' component={ViewShow} />
       <Route exact path='/judges' component={ManageJudges} />
       <Route component={NotFound} />
     </Switch>

--- a/frontend/src/Admin/components/ShowCard.js
+++ b/frontend/src/Admin/components/ShowCard.js
@@ -57,7 +57,7 @@ const ShowCard = props => (
           <Button
             style={{ cursor: 'pointer' }}
             tag={Link}
-            to={`show/${props.id}/judges`}
+            to={`show/${props.id}/judges/assign`}
           >
             Manage Judges
           </Button>

--- a/frontend/src/Admin/components/ShowCard.js
+++ b/frontend/src/Admin/components/ShowCard.js
@@ -50,9 +50,9 @@ const ShowCard = props => (
           <Button
             style={{ cursor: 'pointer' }}
             tag={Link}
-            to={`show/${props.id}/submissions`}
+            to={`show/${props.id}`}
           >
-            View Submissions
+            View Details
           </Button>{' '}
           <Button
             style={{ cursor: 'pointer' }}

--- a/frontend/src/Admin/components/ShowDetailsTab.js
+++ b/frontend/src/Admin/components/ShowDetailsTab.js
@@ -1,0 +1,5 @@
+import React from 'react'
+
+export default function () {
+  return 'Details'
+}

--- a/frontend/src/Admin/components/ShowJudgesTab.js
+++ b/frontend/src/Admin/components/ShowJudgesTab.js
@@ -1,0 +1,5 @@
+import React from 'react'
+
+export default function () {
+  return 'Judges'
+}

--- a/frontend/src/Admin/components/ShowSubmissionsTab.js
+++ b/frontend/src/Admin/components/ShowSubmissionsTab.js
@@ -1,0 +1,5 @@
+import React from 'react'
+
+export default function () {
+  return 'Submissions'
+}

--- a/frontend/src/Admin/pages/ViewShow.js
+++ b/frontend/src/Admin/pages/ViewShow.js
@@ -1,15 +1,141 @@
 import React from 'react'
-import { Link } from 'react-router-dom'
-import { Container, Row, Col } from 'reactstrap'
+import { graphql, compose } from 'react-apollo'
+import { connect } from 'react-redux'
+import PropTypes from 'prop-types'
+import {
+  TabContent,
+  TabPane,
+  Nav,
+  NavItem,
+  NavLink,
+  Container,
+  Row,
+  Col
+} from 'reactstrap'
+import queryString from 'query-string'
 
-const ViewShow = () => (
-  <Container>
-    <Row>
-      <Col>
-        <h1>ViewShow</h1>
-      </Col>
-    </Row>
-  </Container>
-)
+import ShowQuery from '../queries/show.graphql'
 
-export default ViewShow
+class ViewShow extends React.Component {
+  static propTypes = {
+    loading: PropTypes.bool.isRequired,
+    show: PropTypes.shape({
+      name: PropTypes.string.isRequired
+    })
+  }
+
+  goToTab (tab) {
+    if (tab === this.props.tab) {
+      return
+    }
+    const { id: showId } = this.props.match.params
+    const newQueryString = queryString.stringify({
+      ...queryString.parse(this.props.location.search),
+      tab: tab
+    })
+    this.props.history.push(`/show/${showId}?${newQueryString}`)
+  }
+
+  render () {
+    if (this.props.loading) {
+      return null
+    }
+
+    return (
+      <Container>
+        <Row>
+          <Col>
+            <h1>{this.props.show.name}</h1>
+          </Col>
+        </Row>
+        <hr />
+        <Nav tabs>
+          <NavItem>
+            <NavLink
+              className={this.props.tab === '1' ? 'active' : ''}
+              style={{ cursor: 'pointer' }}
+              onClick={() => this.goToTab('1')}
+            >
+              Details
+            </NavLink>
+          </NavItem>
+          <NavItem>
+            <NavLink
+              className={this.props.tab === '2' ? 'active' : ''}
+              style={{ cursor: 'pointer' }}
+              onClick={() => this.goToTab('2')}
+            >
+              Submissions
+            </NavLink>
+          </NavItem>
+          <NavItem>
+            <NavLink
+              className={this.props.tab === '3' ? 'active' : ''}
+              style={{ cursor: 'pointer' }}
+              onClick={() => this.goToTab('3')}
+            >
+              Judges
+            </NavLink>
+          </NavItem>
+        </Nav>
+        <TabContent activeTab={this.props.tab}>
+          <TabPane tabId='1'>
+            <Row>
+              <Col>Details</Col>
+            </Row>
+          </TabPane>
+          <TabPane tabId='2'>
+            <Row>
+              <Col>Submissions</Col>
+            </Row>
+          </TabPane>
+          <TabPane tabId='3'>
+            <Row>
+              <Col>Judges</Col>
+            </Row>
+          </TabPane>
+        </TabContent>
+      </Container>
+    )
+  }
+}
+
+const mapStateToProps = (state, ownProps) => {
+  let { tab } = queryString.parse(ownProps.location.search)
+  const { id: showId } = ownProps.match.params
+
+  // If tab is invalid, destroy it
+  if (tab !== '1' && tab !== '2' && tab !== '3') {
+    tab = null
+  }
+
+  if (!tab) {
+    // Update the query-string to contain the currently active tab, if needed
+    const newQueryString = queryString.stringify({
+      ...queryString.parse(ownProps.location.search),
+      tab: '1'
+    })
+    ownProps.history.replace(`/show/${showId}?${newQueryString}`)
+  }
+
+  return {
+    tab
+  }
+}
+
+const withQuery = compose(
+  connect(mapStateToProps, null),
+  graphql(ShowQuery, {
+    options: ownProps => ({
+      variables: {
+        id: ownProps.match.params.id
+      }
+    }),
+    props: ({ data: { show, loading } }) => ({
+      show,
+      loading
+    })
+  })
+)(ViewShow)
+
+export default withQuery

--- a/frontend/src/Admin/pages/ViewShow.js
+++ b/frontend/src/Admin/pages/ViewShow.js
@@ -78,7 +78,9 @@ const ViewShow = props => {
 
 ViewShow.propTypes = {
   loading: PropTypes.bool.isRequired,
-  show: PropTypes.object,
+  show: PropTypes.shape({
+    name: PropTypes.string.isRequired
+  }),
   match: PropTypes.shape({
     path: PropTypes.string.isRequired,
     url: PropTypes.string.isRequired

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -6721,6 +6721,13 @@ react-router-dom@^4.2.2:
     react-router "^4.2.0"
     warning "^3.0.0"
 
+react-router-tabs@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/react-router-tabs/-/react-router-tabs-1.1.1.tgz#564db9aae301e7ace46681bafed3018c7fda428f"
+  dependencies:
+    prop-types "^15.6.0"
+    react-router-dom "^4.2.2"
+
 react-router@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/react-router/-/react-router-4.2.0.tgz#61f7b3e3770daeb24062dae3eedef1b054155986"


### PR DESCRIPTION
Adds `/show/:id?tab={1,2,3}` to the Admin interface, with three tabs 'Details', 'Submissions', and 'Judge'