### PR TITLE
clear apollo cache after submitting entry

### DIFF
--- a/frontend/src/Student/components/OtherMediaSubmissionForm.js
+++ b/frontend/src/Student/components/OtherMediaSubmissionForm.js
@@ -149,7 +149,11 @@ class OtherSubmissionForm extends Component {
   }
 
   render () {
-    if (this.props.data.loading) {
+    // Since we are clearing the Apollo cache when we submit an entry
+    // there is a brief period where the data is not present but we are not
+    // 'loading' -- this is only for a moment until we are taken back to the
+    // home page.
+    if (this.props.data.loading || !this.props.data.show) {
       return null
     }
 

--- a/frontend/src/Student/components/PhotoSubmissionForm.js
+++ b/frontend/src/Student/components/PhotoSubmissionForm.js
@@ -139,7 +139,11 @@ class PhotoSubmissionForm extends Component {
   }
 
   render () {
-    if (this.props.data.loading) {
+    // Since we are clearing the Apollo cache when we submit an entry
+    // there is a brief period where the data is not present but we are not
+    // 'loading' -- this is only for a moment until we are taken back to the
+    // home page.
+    if (this.props.data.loading || !this.props.data.show) {
       return null
     }
 

--- a/frontend/src/Student/components/VideoSubmissionForm.js
+++ b/frontend/src/Student/components/VideoSubmissionForm.js
@@ -72,7 +72,11 @@ class VideoSubmissionForm extends Component {
   }
 
   render () {
-    if (this.props.data.loading) {
+    // Since we are clearing the Apollo cache when we submit an entry
+    // there is a brief period where the data is not present but we are not
+    // 'loading' -- this is only for a moment until we are taken back to the
+    // home page.
+    if (this.props.data.loading || !this.props.data.show) {
       return null
     }
 

--- a/frontend/src/Student/containers/OtherMediaSubmissionForm.js
+++ b/frontend/src/Student/containers/OtherMediaSubmissionForm.js
@@ -29,7 +29,10 @@ const withMutations = compose(
     props: ({ mutate }) => ({
       create: entry =>
         mutate({
-          variables: { input: entry }
+          variables: { input: entry },
+          update: cache => {
+            cache.reset()
+          }
         })
     })
   }),

--- a/frontend/src/Student/containers/PhotoSubmissionForm.js
+++ b/frontend/src/Student/containers/PhotoSubmissionForm.js
@@ -29,7 +29,10 @@ const withMutations = compose(
     props: ({ mutate }) => ({
       create: entry =>
         mutate({
-          variables: { input: entry }
+          variables: { input: entry },
+          update: cache => {
+            cache.reset()
+          }
         })
     })
   }),

--- a/frontend/src/Student/containers/VideoSubmissionForm.js
+++ b/frontend/src/Student/containers/VideoSubmissionForm.js
@@ -23,7 +23,10 @@ const withMutations = compose(
     props: ({ mutate }) => ({
       create: entry =>
         mutate({
-          variables: { input: entry }
+          variables: { input: entry },
+          update: cache => {
+            cache.reset()
+          }
         })
     })
   }),


### PR DESCRIPTION
Clears the Apollo in-memory cache after an Entry is submitted: this causes graphql to refetch the summary Shows data and when redirected back the homepage the student can find their entry listed there.

Addresses #231 