### PR TITLE
Add Voting Progress to Voting Page

### DIFF
--- a/frontend/src/Admin/containers/ShowDetailsTab.js
+++ b/frontend/src/Admin/containers/ShowDetailsTab.js
@@ -1,4 +1,3 @@
-import React from 'react'
 import { connect } from 'react-redux'
 
 import { getDownloadToken } from '../../shared/actions'

--- a/frontend/src/Judge/components/ShowCard.js
+++ b/frontend/src/Judge/components/ShowCard.js
@@ -3,7 +3,7 @@ import styled from 'styled-components'
 import { Link } from 'react-router-dom'
 import PropTypes from 'prop-types'
 import Moment from 'react-moment'
-import { Button, Row, Col } from 'reactstrap'
+import { Button, Col } from 'reactstrap'
 import moment from 'moment'
 
 const Card = styled.div`

--- a/frontend/src/Judge/pages/Vote.js
+++ b/frontend/src/Judge/pages/Vote.js
@@ -7,12 +7,10 @@ import FaChevronLeft from 'react-icons/lib/fa/chevron-left'
 import FaChevronRight from 'react-icons/lib/fa/chevron-right'
 import queryString from 'query-string'
 import { compose } from 'recompose'
-import { graphql } from 'react-apollo'
 
 import { setViewing, fetchSubmissions, fetchVotes } from '../actions'
 import Submission from '../components/Submission'
 import VotePanel from '../containers/VotePanel'
-import ShowsQuery from '../queries/assignedShows.graphql'
 
 const Arrow = styled.span`
   color: white;
@@ -60,13 +58,14 @@ class Vote extends Component {
     }),
     fetchVotes: PropTypes.func.isRequired,
     vote: PropTypes.object,
-    loadingProgress: PropTypes.bool.isRequired,
-    totalEntries: PropTypes.number,
-    totalOwnVotes: PropTypes.number
+    totalSubmissions: PropTypes.number.isRequired,
+    currentIndex: PropTypes.number.isRequired
   }
 
   static defaultProps = {
-    submission: null
+    submission: null,
+    totalSubmissions: 0,
+    currentIndex: 0
   }
 
   handleKeyInput = e => {
@@ -93,7 +92,7 @@ class Vote extends Component {
   }
 
   render () {
-    const { setViewing, submission, previous, next, vote, loadingProgress, totalEntries, totalOwnVotes } = this.props
+    const { setViewing, submission, previous, next, vote, totalSubmissions, currentIndex } = this.props
 
     return (
       <Container fluid>
@@ -113,7 +112,7 @@ class Vote extends Component {
             ) : null}
           </Col>
           <Col xs='10'>
-            {loadingProgress ? null : <Progress>{totalOwnVotes} / {totalEntries}</Progress>}
+            <Progress>{currentIndex} / {totalSubmissions}</Progress>
             {submission ? <Submission submission={submission} /> : null}
           </Col>
           <Col xs='1'>
@@ -185,7 +184,9 @@ const mapStateToProps = (state, ownProps) => {
       id: showId
     },
     submission: submissionId !== null ? submissions[submissionId] : null,
-    vote: submissionId !== null ? votes.byEntryId[submissionId] : null
+    vote: submissionId !== null ? votes.byEntryId[submissionId] : null,
+    currentIndex: viewing + 1,
+    totalSubmissions: order.length
   }
 
   // Show the previous button
@@ -216,20 +217,5 @@ const mapDispatchToProps = (dispatch, ownProps) => {
 }
 
 export default compose(
-  connect(mapStateToProps, mapDispatchToProps),
-  graphql(ShowsQuery, {
-    options: () => ({ variables: { date: Date.now() } }),
-    props: ({ data: { self, loading }, ownProps }) => {
-      if (!loading) {
-        const show = self.shows.filter((s) => s.id === ownProps.show.id)[0]
-        return {
-          loadingProgress: loading,
-          totalEntries: show.entries.length,
-          totalOwnVotes: show.ownVotes.length
-        }
-      }
-
-      return { loadingProgress: loading }
-    }
-  })
+  connect(mapStateToProps, mapDispatchToProps)
 )(Vote)


### PR DESCRIPTION
#26 

I'm not happy with this implementation as it fetches `entries` and `ownVotes` for all a Judge's shows, but this was the only way to currently do it without making backend changes.

If someone wants to add in backend changes to get them for an individual show, do that.